### PR TITLE
Add MIGraphX backend scaffolding

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -36,7 +36,7 @@ endif()
 set(BUILD_DISTRIBUTED 0 CACHE BOOL "Build with http support for contributing to distributed training")
 set(USE_BACKEND CACHE STRING "Neural net backend")
 string(TOUPPER "${USE_BACKEND}" USE_BACKEND)
-set_property(CACHE USE_BACKEND PROPERTY STRINGS "" CUDA TENSORRT OPENCL EIGEN ROCM)
+set_property(CACHE USE_BACKEND PROPERTY STRINGS "" CUDA TENSORRT OPENCL EIGEN ROCM MGX)
 
 set(USE_TCMALLOC 0 CACHE BOOL "Use TCMalloc")
 set(NO_GIT_REVISION 0 CACHE BOOL "Disable embedding the git revision into the compiled exe")
@@ -177,6 +177,13 @@ elseif(USE_BACKEND STREQUAL "ROCM")
 
   # Optional: Enable model-size‑based autotuning and other macros
   # add_compile_definitions(HIP_SUPPORTS_FP16)
+
+elseif(USE_BACKEND STREQUAL "MGX")
+  message(STATUS "-DUSE_BACKEND=MGX, using MIGraphX backend.")
+  set(NEURALNET_BACKEND_SOURCES
+    neuralnet/mgxbackend.cpp
+    neuralnet/mgxconvert.cpp
+  )
 
 elseif(USE_BACKEND STREQUAL "")
   message(WARNING "${ColorBoldRed}WARNING: Using dummy neural net backend, intended for non-neural-net testing only, will fail on any code path requiring a neural net. To use neural net, specify -DUSE_BACKEND=CUDA or -DUSE_BACKEND=TENSORRT or -DUSE_BACKEND=OPENCL or -DUSE_BACKEND=EIGEN to compile with the respective backend.${ColorReset}")
@@ -515,6 +522,10 @@ elseif(USE_BACKEND STREQUAL "ROCM")
     MIOpen
     # roc::miopen          # DNN primitives
   )
+elseif(USE_BACKEND STREQUAL "MGX")
+  target_compile_definitions(katago PRIVATE USE_MGX_BACKEND)
+  find_package(migraphx REQUIRED)
+  target_link_libraries(katago migraphx::migraphx)
 elseif(USE_BACKEND STREQUAL "EIGEN")
   target_compile_definitions(katago PRIVATE USE_EIGEN_BACKEND)
   if(NOT (MSVC))

--- a/cpp/command/benchmark.cpp
+++ b/cpp/command/benchmark.cpp
@@ -270,6 +270,9 @@ int MainCmds::benchmark(const vector<string>& args) {
   cout << "If you have a strong GPU capable of FP16 tensor cores (e.g. RX6900XT), "
        << "using the ROCm version of KataGo instead may give a mild performance boost." << endl;
 #endif
+#ifdef USE_MGX_BACKEND
+  cout << "You are currently using the MIGraphX version of KataGo." << endl;
+#endif
 #ifdef USE_EIGEN_BACKEND
   cout << "You are currently using the Eigen (CPU) version of KataGo. Due to having no GPU, it may be slow." << endl;
 #endif

--- a/cpp/main.cpp
+++ b/cpp/main.cpp
@@ -246,6 +246,8 @@ string Version::getKataGoVersionFullInfo() {
 #define STRINGIFY2(x) STRINGIFY(x)
   out << "Compiled with HIP runtime version " << STRINGIFY2(HIP_TARGET_VERSION) << endl;
 #endif
+#elif defined(USE_MGX_BACKEND)
+  out << "Using MIGraphX backend" << endl;
 #elif defined(USE_EIGEN_BACKEND)
   out << "Using Eigen(CPU) backend" << endl;
 #else
@@ -280,6 +282,8 @@ string Version::getGitRevisionWithBackend() {
   s += "-trt";
 #elif defined(USE_ROCM_BACKEND)
   s += "-rocm";
+#elif defined(USE_MGX_BACKEND)
+  s += "-mgx";
 #elif defined(USE_METAL_BACKEND)
   s += "-metal";
 #elif defined(USE_OPENCL_BACKEND)

--- a/cpp/neuralnet/mgxbackend.cpp
+++ b/cpp/neuralnet/mgxbackend.cpp
@@ -1,0 +1,333 @@
+#ifdef USE_MGX_BACKEND
+
+#include <migraphx/migraphx.hpp>
+#include <unistd.h>
+// MIGraphX can parse several serialized model formats such as ONNX, JSON, and
+// MsgPack. For now we will use ONNX as the interchange format when converting
+// KataGo's raw neural net model to something MIGraphX can consume.
+
+#include "mgxconvert.h"
+
+#include "../core/global.h"
+#include "../neuralnet/desc.h"
+#include "../neuralnet/modelversion.h"
+#include "../neuralnet/nninterface.h"
+#include "../neuralnet/nninputs.h"
+
+using namespace std;
+
+void NeuralNet::globalInitialize() {
+  // No global initialization required for MIGraphX
+}
+
+void NeuralNet::globalCleanup() {
+  // No global cleanup required for MIGraphX
+}
+
+struct ComputeContext {
+  int nnXLen;
+  int nnYLen;
+};
+
+ComputeContext* NeuralNet::createComputeContext(
+  const vector<int>& gpuIdxs,
+  Logger* logger,
+  int nnXLen,
+  int nnYLen,
+  const string& openCLTunerFile,
+  const string& homeDataDirOverride,
+  bool openCLReTunePerBoardSize,
+  enabled_t useFP16Mode,
+  enabled_t useNHWCMode,
+  const LoadedModel* loadedModel) {
+  (void)gpuIdxs;
+  (void)logger;
+  (void)openCLTunerFile;
+  (void)homeDataDirOverride;
+  (void)openCLReTunePerBoardSize;
+  (void)useFP16Mode;
+  (void)useNHWCMode;
+  (void)loadedModel;
+  ComputeContext* context = new ComputeContext();
+  context->nnXLen = nnXLen;
+  context->nnYLen = nnYLen;
+  return context;
+}
+
+void NeuralNet::freeComputeContext(ComputeContext* computeContext) {
+  delete computeContext;
+}
+
+// -----------------------------------------------------------------------------
+// Model loading and conversion
+// -----------------------------------------------------------------------------
+
+struct LoadedModel {
+  ModelDesc modelDesc;
+  string rawFile;
+  LoadedModel(const string& file, const string& expectedSha256) {
+    ModelDesc::loadFromFileMaybeGZipped(file, modelDesc, expectedSha256);
+    modelDesc.applyScale8ToReduceActivations();
+    rawFile = file;
+  }
+};
+
+LoadedModel* NeuralNet::loadModelFile(const string& file, const string& expectedSha256) {
+  return new LoadedModel(file, expectedSha256);
+}
+
+void NeuralNet::freeLoadedModel(LoadedModel* loadedModel) {
+  delete loadedModel;
+}
+
+const ModelDesc& NeuralNet::getModelDesc(const LoadedModel* loadedModel) {
+  return loadedModel->modelDesc;
+}
+
+struct MGXModel {
+  migraphx::program program;
+  vector<string> paramNames;
+};
+
+static void convertRawModelToONNX(const LoadedModel* rawModel, const string& outFile, int nnXLen, int nnYLen) {
+  (void)nnXLen;
+  (void)nnYLen;
+
+  string modelPath = rawModel->rawFile;
+  if(!MGXConvert::convertRawToOnnx(modelPath, outFile))
+    throw StringError("Error converting model to ONNX");
+}
+
+struct ModelParser {
+  unique_ptr<MGXModel> build(const LoadedModel* rawModel, int nnXLen, int nnYLen) {
+    string tmpFile = Global::strprintf("/tmp/katago-mgx-%d.onnx", getpid());
+    convertRawModelToONNX(rawModel, tmpFile, nnXLen, nnYLen);
+
+    migraphx::onnx_options options;
+    options.set_default_dim_value(1);
+    options.set_default_loop_iterations(10);
+    options.set_limit_loop_iterations(65535);
+
+    migraphx::program program = migraphx::parse_onnx(tmpFile.c_str(), options);
+    migraphx::target t("gpu");
+    program.compile(t);
+    unlink(tmpFile.c_str());
+
+    unique_ptr<MGXModel> model = make_unique<MGXModel>();
+    model->program = std::move(program);
+    auto paramShapes = model->program.get_parameter_shapes();
+    vector<const char*> names = paramShapes.names();
+    for(const char* n : names)
+      model->paramNames.emplace_back(n);
+    return model;
+  }
+};
+
+struct ComputeHandle {
+  unique_ptr<MGXModel> model;
+  int nnXLen;
+  int nnYLen;
+};
+
+ComputeHandle* NeuralNet::createComputeHandle(
+  ComputeContext* context,
+  const LoadedModel* loadedModel,
+  Logger* logger,
+  int maxBatchSize,
+  bool requireExactNNLen,
+  bool inputsUseNHWC,
+  int gpuIdxForThisThread,
+  int serverThreadIdx) {
+  (void)context;
+  (void)logger;
+  (void)maxBatchSize;
+  (void)requireExactNNLen;
+  (void)inputsUseNHWC;
+  (void)gpuIdxForThisThread;
+  (void)serverThreadIdx;
+  ModelParser parser;
+  auto mgxModel = parser.build(loadedModel, context->nnXLen, context->nnYLen);
+  ComputeHandle* handle = new ComputeHandle();
+  handle->model = std::move(mgxModel);
+  handle->nnXLen = context->nnXLen;
+  handle->nnYLen = context->nnYLen;
+  return handle;
+}
+
+void NeuralNet::freeComputeHandle(ComputeHandle* computeHandle) {
+  delete computeHandle;
+}
+
+bool NeuralNet::isUsingFP16(const ComputeHandle* computeHandle) {
+  (void)computeHandle;
+  return false;
+}
+
+void NeuralNet::printDevices() {
+  // MIGraphX does not currently provide a simple device enumeration API
+}
+
+struct InputBuffers {
+  vector<float> spatial;
+  vector<float> global;
+};
+
+InputBuffers* NeuralNet::createInputBuffers(const LoadedModel* loadedModel, int maxBatchSize, int nnXLen, int nnYLen) {
+  (void)loadedModel;
+  InputBuffers* buffers = new InputBuffers();
+  size_t spatialSize = (size_t)maxBatchSize * NNInputs::NUM_FEATURES * nnXLen * nnYLen;
+  buffers->spatial.resize(spatialSize);
+  buffers->global.resize((size_t)maxBatchSize * NNInputs::NUM_GLOBAL_FEATURES);
+  return buffers;
+}
+
+void NeuralNet::freeInputBuffers(InputBuffers* buffers) {
+  delete buffers;
+}
+
+void NeuralNet::getOutput(
+  ComputeHandle* computeHandle,
+  InputBuffers* inputBuffers,
+  int numBatchEltsFilled,
+  NNResultBuf** inputBufs,
+  vector<NNOutput*>& outputs
+) {
+  (void)inputBufs;
+  migraphx::program_parameters params;
+  // Assume first param is spatial input and second is global input
+  if(computeHandle->model->paramNames.size() >= 1) {
+    migraphx::shape spatialShape(
+      migraphx_shape_float_type,
+      {(size_t)numBatchEltsFilled,
+       (size_t)NNInputs::NUM_FEATURES,
+       (size_t)computeHandle->nnXLen,
+       (size_t)computeHandle->nnYLen});
+    migraphx::argument spatialArg(spatialShape, inputBuffers->spatial.data());
+    params.add(computeHandle->model->paramNames[0].c_str(), spatialArg);
+  }
+  if(computeHandle->model->paramNames.size() >= 2) {
+    migraphx::shape globalShape(
+      migraphx_shape_float_type,
+      {(size_t)numBatchEltsFilled,
+       (size_t)NNInputs::NUM_GLOBAL_FEATURES});
+    migraphx::argument globalArg(globalShape, inputBuffers->global.data());
+    params.add(computeHandle->model->paramNames[1].c_str(), globalArg);
+  }
+
+  migraphx::arguments results = computeHandle->model->program.eval(params);
+
+  const float* policyData = nullptr;
+  const float* valueData = nullptr;
+
+  if(results.size() >= 1)
+    policyData = reinterpret_cast<const float*>(results[0].data());
+  if(results.size() >= 2)
+    valueData = reinterpret_cast<const float*>(results[1].data());
+
+  for(int b = 0; b < numBatchEltsFilled; b++) {
+    NNOutput* out = outputs[b];
+    if(policyData != nullptr) {
+      const float* src = policyData + b * NNPos::MAX_NN_POLICY_SIZE;
+      for(int i = 0; i < NNPos::MAX_NN_POLICY_SIZE; i++)
+        out->policyProbs[i] = src[i];
+    }
+    if(valueData != nullptr) {
+      const float* v = valueData + b * 3;
+      out->whiteWinProb = v[0];
+      out->whiteLossProb = v[1];
+      out->whiteNoResultProb = v[2];
+    }
+  }
+}
+
+bool NeuralNet::testEvaluateConv(
+  const ConvLayerDesc* desc,
+  int batchSize,
+  int nnXLen,
+  int nnYLen,
+  bool useFP16,
+  bool useNHWC,
+  const vector<float>& inputBuffer,
+  vector<float>& outputBuffer
+) {
+  (void)desc;
+  (void)batchSize;
+  (void)nnXLen;
+  (void)nnYLen;
+  (void)useFP16;
+  (void)useNHWC;
+  (void)inputBuffer;
+  (void)outputBuffer;
+  return false;
+}
+
+bool NeuralNet::testEvaluateBatchNorm(
+  const BatchNormLayerDesc* desc,
+  int batchSize,
+  int nnXLen,
+  int nnYLen,
+  bool useFP16,
+  bool useNHWC,
+  const vector<float>& inputBuffer,
+  const vector<float>& maskBuffer,
+  vector<float>& outputBuffer
+) {
+  (void)desc;
+  (void)batchSize;
+  (void)nnXLen;
+  (void)nnYLen;
+  (void)useFP16;
+  (void)useNHWC;
+  (void)inputBuffer;
+  (void)maskBuffer;
+  (void)outputBuffer;
+  return false;
+}
+
+bool NeuralNet::testEvaluateResidualBlock(
+  const ResidualBlockDesc* desc,
+  int batchSize,
+  int nnXLen,
+  int nnYLen,
+  bool useFP16,
+  bool useNHWC,
+  const vector<float>& inputBuffer,
+  const vector<float>& maskBuffer,
+  vector<float>& outputBuffer
+) {
+  (void)desc;
+  (void)batchSize;
+  (void)nnXLen;
+  (void)nnYLen;
+  (void)useFP16;
+  (void)useNHWC;
+  (void)inputBuffer;
+  (void)maskBuffer;
+  (void)outputBuffer;
+  return false;
+}
+
+bool NeuralNet::testEvaluateGlobalPoolingResidualBlock(
+  const GlobalPoolingResidualBlockDesc* desc,
+  int batchSize,
+  int nnXLen,
+  int nnYLen,
+  bool useFP16,
+  bool useNHWC,
+  const vector<float>& inputBuffer,
+  const vector<float>& maskBuffer,
+  vector<float>& outputBuffer
+) {
+  (void)desc;
+  (void)batchSize;
+  (void)nnXLen;
+  (void)nnYLen;
+  (void)useFP16;
+  (void)useNHWC;
+  (void)inputBuffer;
+  (void)maskBuffer;
+  (void)outputBuffer;
+  return false;
+}
+
+#endif // USE_MGX_BACKEND

--- a/cpp/neuralnet/mgxconvert.cpp
+++ b/cpp/neuralnet/mgxconvert.cpp
@@ -1,0 +1,922 @@
+#include "mgxconvert.h"
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+
+namespace MGXConvert {
+
+  static const char* PYTHON_SCRIPT = R"PY(
+import json
+import struct
+from argparse import ArgumentParser
+
+import numpy as np
+import torch
+import torch.onnx
+from packaging import version
+import onnxmltools
+from onnxmltools.utils.float16_converter import convert_float_to_float16
+
+
+# -----------------------------------------------------------------------------
+# Low-level operations and helpers
+# -----------------------------------------------------------------------------
+
+
+def norm(C_in, norm_name="FixUp", affine=True, fixup_use_gamma=False):
+    if norm_name == "BN":
+        return torch.nn.BatchNorm2d(C_in, affine=affine)
+    if norm_name == "AN":
+        return AttenNorm(C_in)
+    if norm_name == "FixUp":
+        return KataFixUp(C_in, fixup_use_gamma)
+    raise NotImplementedError("Unknown feature norm name")
+
+
+def act(activation, inplace=False):
+    if activation == "ReLU":
+        return torch.nn.ReLU(inplace=inplace)
+    if activation == "Hardswish":
+        if version.parse(torch.__version__) > version.parse("1.6.0"):
+            return torch.nn.Hardswish(inplace=inplace)
+        else:
+            return torch.nn.Hardswish()
+    if activation == "Identity":
+        return torch.nn.Identity()
+    raise NotImplementedError("Unknown activation name")
+
+
+def conv1x1(C_in, C_out):
+    return torch.nn.Conv2d(C_in, C_out, 1, 1, 0, bias=False)
+
+
+def conv3x3(C_in, C_out):
+    return torch.nn.Conv2d(C_in, C_out, 3, 1, 1, bias=False)
+
+
+class AttenNorm(torch.nn.BatchNorm2d):
+    def __init__(
+        self, num_features, K=5, eps=1e-5, momentum=0.1, track_running_stats=True
+    ):
+        super(AttenNorm, self).__init__(
+            num_features,
+            eps=eps,
+            momentum=momentum,
+            affine=False,
+            track_running_stats=track_running_stats,
+        )
+        self.gamma = torch.nn.Parameter(torch.Tensor(K, num_features))
+        self.beta = torch.nn.Parameter(torch.Tensor(K, num_features))
+        self.avgpool = torch.nn.AdaptiveAvgPool2d(1)
+        self.fc = torch.nn.Linear(num_features, K)
+        self.sigmoid = torch.nn.Sigmoid()
+
+    def forward(self, x):
+        output = super(AttenNorm, self).forward(x)
+        size = output.size()
+        b, c, _, _ = x.size()
+        y = self.avgpool(x).view(b, c)
+        y = self.fc(y)
+        y = self.sigmoid(y)
+        gamma = y @ self.gamma
+        beta = y @ self.beta
+        gamma = gamma.unsqueeze(-1).unsqueeze(-1).expand(size)
+        beta = beta.unsqueeze(-1).unsqueeze(-1).expand(size)
+        return gamma * output + beta
+
+
+class KataFixUp(torch.nn.Module):
+    def __init__(self, C_in, use_gamma):
+        super(KataFixUp, self).__init__()
+        self.use_gamma = use_gamma
+        if self.use_gamma:
+            self.gamma = torch.nn.Parameter(torch.ones(1, C_in, 1, 1))
+        self.beta = torch.nn.Parameter(torch.zeros(1, C_in, 1, 1))
+
+    def forward(self, x):
+        if self.use_gamma:
+            return x * self.gamma + self.beta
+        else:
+            return x + self.beta
+
+
+class NormMask(torch.nn.Module):
+    def __init__(self, C_in, normalization="FixUp", affine=True, fixup_use_gamma=False):
+        super(NormMask, self).__init__()
+        self._norm = norm(C_in, normalization, affine, fixup_use_gamma)
+
+    def forward(self, x, mask):
+        return self._norm(x)
+
+
+class NormMaskActConv(torch.nn.Module):
+    def __init__(
+        self,
+        C_in,
+        C_out,
+        kernel_size,
+        padding,
+        affine=True,
+        activation="ReLU",
+        normalization="FixUp",
+        fixup_use_gamma=False,
+    ):
+        super(NormMaskActConv, self).__init__()
+        self.norm = NormMask(
+            C_in, normalization, affine=affine, fixup_use_gamma=fixup_use_gamma
+        )
+        self.act = act(activation, inplace=False)
+        self.conv = torch.nn.Conv2d(
+            C_in, C_out, kernel_size, padding=padding, bias=False
+        )
+
+    def forward(self, x, mask):
+        out = self.norm(x, mask)
+        out = self.act(out)
+        out = self.conv(out)
+        return out
+
+
+class NormMaskActConv3x3(torch.nn.Module):
+    def __init__(
+        self,
+        C_in,
+        C_out,
+        affine=True,
+        activation="ReLU",
+        normalization="FixUp",
+        fixup_use_gamma=False,
+    ):
+        super(NormMaskActConv3x3, self).__init__()
+        self.op = NormMaskActConv(
+            C_in,
+            C_out,
+            kernel_size=3,
+            padding=1,
+            affine=affine,
+            activation=activation,
+            normalization=normalization,
+            fixup_use_gamma=fixup_use_gamma,
+        )
+
+    def forward(self, x, mask):
+        return self.op(x, mask)
+
+
+class NormMaskActConv1x1(torch.nn.Module):
+    def __init__(
+        self,
+        C_in,
+        C_out,
+        affine=True,
+        activation="ReLU",
+        normalization="FixUp",
+        fixup_use_gamma=False,
+    ):
+        super(NormMaskActConv1x1, self).__init__()
+        self.op = NormMaskActConv(
+            C_in,
+            C_out,
+            kernel_size=1,
+            padding=0,
+            affine=affine,
+            activation=activation,
+            normalization=normalization,
+            fixup_use_gamma=fixup_use_gamma,
+        )
+
+    def forward(self, x, mask):
+        return self.op(x, mask)
+
+
+# -----------------------------------------------------------------------------
+# Model basis building blocks
+# -----------------------------------------------------------------------------
+
+
+class KataGPool(torch.nn.Module):
+    def __init__(self):
+        super(KataGPool, self).__init__()
+
+    def forward(self, x, mask):
+        mask_sum_hw = mask.sum(dim=(1, 2, 3))
+        mask_sum_hw_sqrt = mask_sum_hw.sqrt()
+        div = mask_sum_hw.reshape((-1, 1, 1, 1))
+        div_sqrt = mask_sum_hw_sqrt.reshape((-1, 1, 1, 1))
+
+        layer_mean = x.sum(dim=(2, 3), keepdim=True) / div
+        layer_max = x.max(dim=3, keepdim=True)[0].max(dim=2, keepdim=True)[0]
+        out_pool1 = layer_mean
+        out_pool2 = layer_mean * (div_sqrt - 14.0) / 10.0
+        out_pool3 = layer_max
+
+        out = torch.cat((out_pool1, out_pool2, out_pool3), 1)
+        return out
+
+
+class KataValueHeadGPool(torch.nn.Module):
+    def __init__(self):
+        super(KataValueHeadGPool, self).__init__()
+
+    def forward(self, x, mask):
+        mask_sum_hw = mask.sum(dim=(1, 2, 3))
+        mask_sum_hw_sqrt = mask_sum_hw.sqrt()
+        div = mask_sum_hw.reshape((-1, 1, 1, 1))
+        div_sqrt = mask_sum_hw_sqrt.reshape((-1, 1, 1, 1))
+
+        layer_mean = x.sum(dim=(2, 3), keepdim=True) / div
+
+        out_pool1 = layer_mean
+        out_pool2 = layer_mean * (div_sqrt - 14.0) / 10.0
+        out_pool3 = layer_mean * ((div_sqrt - 14.0) * (div_sqrt - 14.0) / 100.0 - 0.1)
+
+        out = torch.cat((out_pool1, out_pool2, out_pool3), 1)
+        return out
+
+
+class KataGPoolCell(torch.nn.Module):
+    def __init__(self, C_in, C_gpool, C_regular, activation, normalization):
+        super(KataGPoolCell, self).__init__()
+        self.norm1 = NormMask(C_in, normalization)
+        self.act1 = act(activation)
+        self.conv1_3x3 = conv3x3(C_in, C_regular)
+        self.conv2_3x3 = conv3x3(C_in, C_gpool)
+        self.norm2 = NormMask(C_gpool, normalization)
+        self.act2 = act(activation)
+        self.gpool = KataGPool()
+        self.linear = torch.nn.Linear(3 * C_gpool, C_regular, bias=False)
+
+    def forward(self, x, mask):
+        out0 = self.norm1(x, mask)
+        out0 = self.act1(out0)
+        out1 = self.conv1_3x3(out0)
+        out2 = self.conv2_3x3(out0)
+        out2 = self.norm2(out2, mask)
+        out2 = self.act2(out2)
+        out3 = self.gpool(out2, mask).squeeze()
+        out3 = self.linear(out3).unsqueeze(-1).unsqueeze(-1)
+        out = out1 + out3
+        return out
+
+
+class ResBlock(torch.nn.Module):
+    def __init__(self, C_in, activation, normalization):
+        super(ResBlock, self).__init__()
+        self.conv1_3x3 = NormMaskActConv3x3(
+            C_in, C_in, activation=activation, normalization=normalization
+        )
+        self.conv2_3x3 = NormMaskActConv3x3(
+            C_in,
+            C_in,
+            activation=activation,
+            normalization=normalization,
+            fixup_use_gamma=True,
+        )
+
+    def forward(self, x, mask):
+        residual = x
+        out = self.conv1_3x3(x, mask)
+        out = self.conv2_3x3(out, mask)
+        out += residual
+        return out
+
+
+class GpoolResBlock(torch.nn.Module):
+    def __init__(self, C_in, C_gpool, C_regular, activation, normalization):
+        super(GpoolResBlock, self).__init__()
+        self.pool = KataGPoolCell(
+            C_in, C_gpool, C_regular, activation=activation, normalization=normalization
+        )
+        self.conv1_3x3 = NormMaskActConv3x3(
+            C_regular,
+            C_in,
+            activation=activation,
+            normalization=normalization,
+            fixup_use_gamma=True,
+        )
+
+    def forward(self, x, mask):
+        residual = x
+        out = self.pool(x, mask)
+        out = self.conv1_3x3(out, mask)
+        out += residual
+        return out
+
+
+class PolicyHead(torch.nn.Module):
+    def __init__(self, C_in, C_p, C_pg, activation, normalization):
+        super(PolicyHead, self).__init__()
+        self.conv1_1x1 = conv1x1(C_in, C_p)
+        self.conv2_1x1 = conv1x1(C_in, C_pg)
+        self.norm1 = NormMask(C_pg, normalization)
+        self.act1 = act(activation)
+        self.gpool = KataGPool()
+        self.linear_pass = torch.nn.Linear(3 * C_pg, 1, bias=False)
+        self.linear = torch.nn.Linear(3 * C_pg, C_p, bias=False)
+        self.conv3_1x1 = NormMaskActConv1x1(
+            C_p, 1, activation=activation, normalization=normalization
+        )
+
+    def forward(self, x, mask):
+        out_p = self.conv1_1x1(x)
+        out_g = self.conv2_1x1(x)
+        out_g = self.norm1(out_g, mask)
+        out_g = self.act1(out_g)
+        out_pool = self.gpool(out_g, mask).squeeze()
+        out_pass = self.linear_pass(out_pool)
+
+        out_pool = self.linear(out_pool).unsqueeze(-1).unsqueeze(-1)
+        out_p += out_pool
+        out_policy = self.conv3_1x1(out_p, mask)
+        out_policy = out_policy - (1.0 - mask) * 5000.0
+        out_policy = out_policy.flatten(start_dim=1)
+        out_pass = out_pass.reshape((-1, 1))
+        return torch.cat((out_policy, out_pass), -1)
+
+
+class ValueHead(torch.nn.Module):
+    def __init__(self, C_in, C_v1, C_v2, activation, normalization):
+        super(ValueHead, self).__init__()
+        self.init_conv = conv1x1(C_in, C_v1)
+        self.norm1 = NormMask(C_v1, normalization)
+        self.act1 = act(activation)
+        self.vh_gpool = KataValueHeadGPool()
+        self.linear_after_pool = torch.nn.Linear(3 * C_v1, C_v2)
+        self.act_after_pool = act(activation)
+        self.linear_valuehead = torch.nn.Linear(C_v2, 3)
+        self.linear_miscvaluehead = torch.nn.Linear(C_v2, 4)
+        self.conv_ownership = conv1x1(C_v1, 1)
+
+    def forward(self, x, mask):
+        out_v1 = self.init_conv(x)
+        out_v1 = self.norm1(out_v1, mask)
+        out_v1 = self.act1(out_v1)
+        out_pooled = self.vh_gpool(out_v1, mask).squeeze()
+        out_pooled = self.linear_after_pool(out_pooled)
+        out_v2 = self.act_after_pool(out_pooled)
+        out_value = self.linear_valuehead(out_v2)
+        out_miscvalue = self.linear_miscvaluehead(out_v2)
+        out_ownership = self.conv_ownership(out_v1)
+        return out_value, out_miscvalue, out_ownership
+
+
+class KataGoInferenceModel(torch.nn.Module):
+    def __init__(self, conf):
+        super(KataGoInferenceModel, self).__init__()
+
+        self.conf = conf
+        self.block_kind = conf["config"]["block_kind"]
+        self.C = conf["config"]["trunk_num_channels"]
+        self.C_mid = conf["config"]["mid_num_channels"]
+        self.C_gpool = conf["config"]["gpool_num_channels"]
+        self.C_regular = conf["config"]["regular_num_channels"]
+        self.C_p = conf["config"]["p1_num_channels"]
+        self.C_pg = conf["config"]["g1_num_channels"]
+        self.C_v1 = conf["config"]["v1_num_channels"]
+        self.C_v2 = conf["config"]["v2_size"]
+        self.activation = "ReLU"
+        if conf["config"]["use_fixup"]:
+            self.normalization = "FixUp"
+        else:
+            self.normalization = "BN"
+
+        bin_in = conf["initial_conv"]["C_in"]
+        diam_y = conf["initial_conv"]["diam_y"]
+        diam_x = conf["initial_conv"]["diam_x"]
+        dil_y = conf["initial_conv"]["dil_y"]
+        dil_x = conf["initial_conv"]["dil_x"]
+        pad_y = (diam_y // 2) * dil_y
+        pad_x = (diam_x // 2) * dil_x
+        glob_in = conf["initial_matmul"]["C_in"]
+
+        self.linear_ginput = torch.nn.Linear(glob_in, self.C, bias=False)
+        self.conv1 = torch.nn.Conv2d(
+            bin_in,
+            self.C,
+            (diam_y, diam_x),
+            1,
+            (pad_y, pad_x),
+            bias=False,
+            dilation=(dil_y, dil_x),
+        )
+
+        self.blocks = torch.nn.ModuleList()
+        for block_conf in self.block_kind:
+            if block_conf[1] == "regular":
+                self.blocks += [ResBlock(self.C, self.activation, self.normalization)]
+            elif block_conf[1] == "gpool":
+                self.blocks += [
+                    GpoolResBlock(
+                        self.C,
+                        self.C_gpool,
+                        self.C_regular,
+                        self.activation,
+                        self.normalization,
+                    )
+                ]
+            else:
+                assert False
+
+        self.norm1 = NormMask(self.C, self.normalization)
+        self.act1 = act(self.activation)
+        self.policy_head = PolicyHead(
+            self.C, self.C_p, self.C_pg, self.activation, self.normalization
+        )
+        self.value_head = ValueHead(
+            self.C, self.C_v1, self.C_v2, self.activation, self.normalization
+        )
+
+    def forward(self, input_binary, input_global):
+        mask = input_binary[:, 0:1, :, :]
+
+        x_bin = self.conv1(input_binary)
+        x_global = self.linear_ginput(input_global).unsqueeze(-1).unsqueeze(-1)
+        out = x_bin + x_global
+
+        for block in self.blocks:
+            out = block(out, mask)
+
+        out = self.norm1(out, mask)
+        out = self.act1(out)
+
+        out_policy = self.policy_head(out, mask)
+        (out_value, out_miscvalue, out_ownership) = self.value_head(out, mask)
+
+        return (
+            out_policy,
+            out_value,
+            out_miscvalue,
+            out_ownership,
+        )
+
+    def fill_misc_weights(self, conv1_weight, linear_ginput_weight, norm1_weight):
+        self.conv1.weight.data = conv1_weight
+        self.linear_ginput.weight.data = linear_ginput_weight
+        self.norm1._norm.beta.data = norm1_weight
+
+    def fill_regular_block(self, block, block_dict):
+        block.conv1_3x3.op.norm._norm.beta.data = block_dict["norm1"]["beta"]
+        block.conv1_3x3.op.conv.weight.data = block_dict["conv1"]["weights"]
+        block.conv2_3x3.op.norm._norm.gamma.data = block_dict["norm2"]["gamma"]
+        block.conv2_3x3.op.norm._norm.beta.data = block_dict["norm2"]["beta"]
+        block.conv2_3x3.op.conv.weight.data = block_dict["conv2"]["weights"]
+
+    def fill_gpool_block(self, block, block_dict):
+        block.pool.norm1._norm.beta.data = block_dict["norm1"]["beta"]
+        block.pool.conv1_3x3.weight.data = block_dict["conv1"]["weights"]
+        block.pool.conv2_3x3.weight.data = block_dict["conv2"]["weights"]
+        block.pool.norm2._norm.beta.data = block_dict["norm2"]["beta"]
+        block.pool.linear.weight.data = block_dict["matmul1"]["weights"]
+        block.conv1_3x3.op.norm._norm.gamma.data = block_dict["norm3"]["gamma"]
+        block.conv1_3x3.op.norm._norm.beta.data = block_dict["norm3"]["beta"]
+        block.conv1_3x3.op.conv.weight.data = block_dict["conv3"]["weights"]
+
+    def fill_policy_head(self, policy_dict):
+        self.policy_head.conv1_1x1.weight.data = policy_dict["convp"]["weights"]
+        self.policy_head.conv2_1x1.weight.data = policy_dict["convg"]["weights"]
+        self.policy_head.norm1._norm.beta.data = policy_dict["normg"]["beta"]
+        self.policy_head.linear_pass.weight.data = policy_dict["matmulpass"]["weights"]
+        self.policy_head.linear.weight.data = policy_dict["matmulg"]["weights"]
+        self.policy_head.conv3_1x1.op.norm._norm.beta.data = policy_dict["norm2"]["beta"]
+        self.policy_head.conv3_1x1.op.conv.weight.data = policy_dict["conv3"]["weights"]
+
+    def fill_value_head(self, value_dict):
+        self.value_head.init_conv.weight.data = value_dict["conv1"]["weights"]
+        self.value_head.norm1._norm.beta.data = value_dict["norm1"]["beta"]
+        self.value_head.linear_after_pool.weight.data = value_dict["matmul1"]["weights"]
+        self.value_head.linear_after_pool.bias.data = value_dict["matbias1"]["weights"]
+        self.value_head.linear_valuehead.weight.data = value_dict["matmul2"]["weights"]
+        self.value_head.linear_valuehead.bias.data = value_dict["matbias2"]["weights"]
+        self.value_head.linear_miscvaluehead.weight.data = value_dict["matmul3"]["weights"]
+        self.value_head.linear_miscvaluehead.bias.data = value_dict["matbias3"]["weights"]
+        self.value_head.conv_ownership.weight.data = value_dict["conv2"]["weights"]
+
+    def fill_weights(self):
+        print("Filling misc weights")
+        self.fill_misc_weights(
+            self.conf["initial_conv"]["weights"],
+            self.conf["initial_matmul"]["weights"],
+            self.conf["postprocess_norm"]["beta"],
+        )
+        for i, block_conf in enumerate(self.block_kind):
+            print(f"Filling block {i} weights ({block_conf[1]})")
+            if block_conf[1] == "regular":
+                self.fill_regular_block(self.blocks[i], self.conf["blocks"][i])
+            elif block_conf[1] == "gpool":
+                self.fill_gpool_block(self.blocks[i], self.conf["blocks"][i])
+            else:
+                assert False
+        print("Filling policy head weights")
+        self.fill_policy_head(self.conf["policy_head"])
+        print("Filling value head weights")
+        self.fill_value_head(self.conf["value_head"])
+
+
+# -----------------------------------------------------------------------------
+# Netparser for KataGo binary model
+# -----------------------------------------------------------------------------
+
+
+def bin2str(binary_str):
+    return binary_str.decode(encoding="ascii", errors="backslashreplace")
+
+
+def read_header(lines, idx):
+    header_dict = {
+        "type": "header",
+        "name": bin2str(lines[idx + 0]),
+        "version": int(lines[idx + 1]),
+        "num_bin_input_features": int(lines[idx + 2]),
+        "num_global_input_features": int(lines[idx + 3]),
+        "num_blocks": int(lines[idx + 5]),
+        "num_channels": int(lines[idx + 6]),
+        "num_mid_channels": int(lines[idx + 7]),
+        "num_regular_channels": int(lines[idx + 8]),
+        "num_dilated_channels": int(lines[idx + 9]),
+        "num_gpool_channels": int(lines[idx + 10]),
+    }
+
+    return header_dict, idx + 11
+
+
+def read_weights(lines, idx, shape):
+    assert lines[idx][0:5] == b"@BIN@"
+    buffer_size = struct.calcsize(f"<{np.prod(shape)}f")
+
+    i_increment = 0
+    buffer = lines[idx][5:]
+    while len(buffer) < buffer_size:
+        buffer += "\n".encode(encoding="ascii", errors="backslashreplace")
+        if len(buffer) == buffer_size:
+            break
+        i_increment += 1
+        buffer += lines[idx + i_increment]
+    assert buffer_size == len(buffer)
+    weights = np.array(struct.unpack(f"<{np.prod(shape)}f", buffer))
+    weights = torch.tensor(weights.reshape(shape), dtype=torch.float)
+
+    return weights, i_increment
+
+
+def read_conv(lines, idx):
+    diam_y = int(lines[idx + 1])
+    diam_x = int(lines[idx + 2])
+    C_in = int(lines[idx + 3])
+    C_out = int(lines[idx + 4])
+    weights, i_increment = read_weights(lines, idx + 7, (diam_y, diam_x, C_in, C_out))
+
+    conv_dict = {
+        "type": "conv",
+        "name": bin2str(lines[idx]),
+        "diam_y": diam_y,
+        "diam_x": diam_x,
+        "C_in": C_in,
+        "C_out": C_out,
+        "dil_y": int(lines[idx + 5]),
+        "dil_x": int(lines[idx + 6]),
+        "weights": weights.permute(3, 2, 0, 1),
+    }
+
+    return conv_dict, idx + 8 + i_increment
+
+
+def read_norm(lines, idx):
+    C_in = int(lines[idx + 1])
+    norm_dict = {
+        "type": "norm",
+        "name": bin2str(lines[idx]),
+        "C_in": C_in,
+        "eps": float(lines[idx + 2]),
+        "has_scale": bool(int(lines[idx + 3])),
+        "has_bias": bool(int(lines[idx + 4])),
+    }
+
+    idx_increment = 0
+
+    moving_mean, i_increment = read_weights(lines, idx + 5 + idx_increment, (C_in))
+    norm_dict["moving_mean"] = moving_mean.unsqueeze(0).unsqueeze(-1).unsqueeze(-1)
+    idx_increment += 1 + i_increment
+
+    moving_variance, i_increment = read_weights(lines, idx + 5 + idx_increment, (C_in))
+    norm_dict["moving_variance"] = (
+        moving_variance.unsqueeze(0).unsqueeze(-1).unsqueeze(-1)
+    )
+    idx_increment += 1 + i_increment
+
+    if norm_dict["has_scale"]:
+        gamma, i_increment = read_weights(lines, idx + 5 + idx_increment, (C_in))
+        norm_dict["gamma"] = gamma.unsqueeze(0).unsqueeze(-1).unsqueeze(-1)
+        idx_increment += 1 + i_increment
+
+    if norm_dict["has_bias"]:
+        beta, i_increment = read_weights(lines, idx + 5 + idx_increment, (C_in))
+        norm_dict["beta"] = beta.unsqueeze(0).unsqueeze(-1).unsqueeze(-1)
+        idx_increment += 1 + i_increment
+
+    return norm_dict, idx + 5 + idx_increment
+
+
+def read_act(lines, idx):
+    act_dict = {"type": "act", "act": bin2str(lines[idx])}
+
+    return act_dict, idx + 1
+
+
+def read_matmul(lines, idx):
+    C_in = int(lines[idx + 1])
+    C_out = int(lines[idx + 2])
+    weights, i_increment = read_weights(lines, idx + 3, (C_in, C_out))
+
+    matmul_dict = {
+        "type": "matmul",
+        "name": bin2str(lines[idx]),
+        "C_in": C_in,
+        "C_out": C_out,
+        "weights": weights.permute(1, 0),
+    }
+
+    return matmul_dict, idx + 4 + i_increment
+
+
+def read_matbias(lines, idx):
+    C_in = int(lines[idx + 1])
+    weights, i_increment = read_weights(lines, idx + 2, (C_in))
+
+    matbias_dict = {
+        "type": "matbias",
+        "name": bin2str(lines[idx]),
+        "C_in": C_in,
+        "weights": weights,
+    }
+
+    return matbias_dict, idx + 3 + i_increment
+
+
+def read_block(lines, idx):
+    block_type = bin2str(lines[idx])
+    name = bin2str(lines[idx + 1])
+    head_idx = idx + 2
+
+    if block_type == "ordinary_block":
+        norm1, head_idx = read_norm(lines, head_idx)
+        act1, head_idx = read_act(lines, head_idx)
+        conv1, head_idx = read_conv(lines, head_idx)
+        norm2, head_idx = read_norm(lines, head_idx)
+        act2, head_idx = read_act(lines, head_idx)
+        conv2, head_idx = read_conv(lines, head_idx)
+
+        block_dict = {
+            "type": block_type,
+            "name": name,
+            "norm1": norm1,
+            "act1": act1,
+            "conv1": conv1,
+            "norm2": norm2,
+            "act2": act2,
+            "conv2": conv2,
+        }
+
+        return block_dict, head_idx
+    if block_type == "gpool_block":
+        norm1, head_idx = read_norm(lines, head_idx)
+        act1, head_idx = read_act(lines, head_idx)
+        conv1, head_idx = read_conv(lines, head_idx)
+        conv2, head_idx = read_conv(lines, head_idx)
+        norm2, head_idx = read_norm(lines, head_idx)
+        act2, head_idx = read_act(lines, head_idx)
+        matmul1, head_idx = read_matmul(lines, head_idx)
+        norm3, head_idx = read_norm(lines, head_idx)
+        act3, head_idx = read_act(lines, head_idx)
+        conv3, head_idx = read_conv(lines, head_idx)
+
+        block_dict = {
+            "type": block_type,
+            "name": name,
+            "norm1": norm1,
+            "act1": act1,
+            "conv1": conv1,
+            "conv2": conv2,
+            "norm2": norm2,
+            "act2": act2,
+            "matmul1": matmul1,
+            "norm3": norm3,
+            "act3": act3,
+            "conv3": conv3,
+        }
+
+        return block_dict, head_idx
+    else:
+        assert False
+
+
+def read_policy_head(lines, idx):
+    name = bin2str(lines[idx])
+    head_idx = idx + 1
+
+    conv1, head_idx = read_conv(lines, head_idx)
+    conv2, head_idx = read_conv(lines, head_idx)
+    norm1, head_idx = read_norm(lines, head_idx)
+    act1, head_idx = read_act(lines, head_idx)
+    matmul1, head_idx = read_matmul(lines, head_idx)
+    norm2, head_idx = read_norm(lines, head_idx)
+    act2, head_idx = read_act(lines, head_idx)
+    conv3, head_idx = read_conv(lines, head_idx)
+    matmul2, head_idx = read_matmul(lines, head_idx)
+
+    policy_head_dict = {
+        "type": "policy head",
+        "name": name,
+        "convp": conv1,
+        "convg": conv2,
+        "normg": norm1,
+        "actg": act1,
+        "matmulg": matmul1,
+        "norm2": norm2,
+        "act2": act2,
+        "conv3": conv3,
+        "matmulpass": matmul2,
+    }
+
+    return policy_head_dict, head_idx
+
+
+def read_value_head(lines, idx):
+    name = bin2str(lines[idx])
+    head_idx = idx + 1
+
+    conv1, head_idx = read_conv(lines, head_idx)
+    norm1, head_idx = read_norm(lines, head_idx)
+    act1, head_idx = read_act(lines, head_idx)
+    matmul1, head_idx = read_matmul(lines, head_idx)
+    matbias1, head_idx = read_matbias(lines, head_idx)
+    act2, head_idx = read_act(lines, head_idx)
+    matmul2, head_idx = read_matmul(lines, head_idx)
+    matbias2, head_idx = read_matbias(lines, head_idx)
+    matmul3, head_idx = read_matmul(lines, head_idx)
+    matbias3, head_idx = read_matbias(lines, head_idx)
+    conv2, head_idx = read_conv(lines, head_idx)
+
+    value_head_dict = {
+        "type": "value head",
+        "name": name,
+        "conv1": conv1,
+        "norm1": norm1,
+        "act1": act1,
+        "matmul1": matmul1,
+        "matbias1": matbias1,
+        "act2": act2,
+        "matmul2": matmul2,
+        "matbias2": matbias2,
+        "matmul3": matmul3,
+        "matbias3": matbias3,
+        "conv2": conv2,
+    }
+
+    return value_head_dict, head_idx
+
+
+def read_model(model_path):
+    model_config = {
+        "version": 16,
+        "support_japanese_rules": True,
+        "use_fixup": True,
+        "use_scoremean_as_lead": False,
+    }
+
+    print(f"Model: {model_path}")
+    with open(model_path, "rb") as f:
+        contents = f.read()
+    lines = contents.split("\n".encode(encoding="ascii", errors="backslashreplace"))
+    print(f"Model file loading completed.")
+
+    head_idx = 0
+    header, head_idx = read_header(lines, head_idx)
+    assert header["version"] == 8
+
+    initial_conv, head_idx = read_conv(lines, head_idx)
+    initial_matmul, head_idx = read_matmul(lines, head_idx)
+
+    blocks = []
+    for i in range(header["num_blocks"]):
+        print(f"Reading block {i}")
+        block, head_idx = read_block(lines, head_idx)
+        blocks.append(block)
+
+    postprocess_norm, head_idx = read_norm(lines, head_idx)
+    postprocess_act, head_idx = read_act(lines, head_idx)
+
+    print("Reading policy head")
+    policy_head, head_idx = read_policy_head(lines, head_idx)
+    print("Reading value head")
+    value_head, head_idx = read_value_head(lines, head_idx)
+
+    model_dict = {
+        "config": model_config,
+        "initial_conv": initial_conv,
+        "initial_matmul": initial_matmul,
+        "blocks": blocks,
+        "postprocess_norm": postprocess_norm,
+        "postprocess_act": postprocess_act,
+        "policy_head": policy_head,
+        "value_head": value_head,
+    }
+
+    return model_dict
+
+
+# -----------------------------------------------------------------------------
+# Conversion utilities
+# -----------------------------------------------------------------------------
+
+
+def convert(model, output):
+    model_spec = read_model(model)
+    model = KataGoInferenceModel(model_spec)
+    print("Model building completed")
+    model.fill_weights()
+
+    bin_in = model_spec["initial_conv"]["C_in"]
+    glob_in = model_spec["initial_matmul"]["C_in"]
+    dummy_input_binary = torch.randn(10, bin_in, 19, 19)
+    dummy_input_binary[:, 0, :, :] = 1.0
+    dummy_input_global = torch.randn(10, glob_in)
+    input_names = ["input_binary", "input_global"]
+    output_names = [
+        "output_policy",
+        "output_value",
+        "output_miscvalue",
+        "output_ownership",
+    ]
+
+    torch.onnx.export(
+        model,
+        (dummy_input_binary, dummy_input_global),
+        output,
+        export_params=True,
+        verbose=True,
+        opset_version=10,
+        do_constant_folding=True,
+        input_names=input_names,
+        output_names=output_names,
+        dynamic_axes={
+            "input_binary": {0: "batch_size", 2: "y_size", 3: "x_size"},
+            "input_global": {0: "batch_size"},
+            "output_policy": {0: "batch_size", 1: "board_area + 1"},
+            "output_value": {0: "batch_size"},
+            "output_miscvalue": {0: "batch_size"},
+            "output_ownership": {0: "batch_size", 2: "y_size", 3: "x_size"},
+        },
+    )
+
+    print(f"ONNX model saved in {output}")
+
+
+def quantize_fp16(input_path, output_path):
+    onnx_model = onnxmltools.utils.load_model(input_path)
+    fp16_model = convert_float_to_float16(onnx_model)
+    onnxmltools.utils.save_model(fp16_model, output_path)
+    print(f"{input_path} is quantized and saved as {output_path}.")
+
+
+if __name__ == "__main__":
+    description = """
+    Convert KataGo .bin model to .onnx file.
+    """
+    parser = ArgumentParser(description)
+    parser.add_argument(
+        "--model", type=str, required=True, help="KataGo .bin network file location"
+    )
+    parser.add_argument(
+        "--output", type=str, default=None, help="Output .onnx network file location"
+    )
+    args = parser.parse_args()
+    if args.output is None:
+        args.output = args.model.replace(".bin", ".onnx")
+    convert(args.model, args.output)
+)PY";
+
+  bool convertRawToOnnx(const std::string& modelPath, const std::string& outPath) {
+    namespace fs = std::filesystem;
+    std::string venvPath = "/tmp/katago_mgx_venv";
+    std::string py = "python3";
+
+    if(!fs::exists(venvPath)) {
+      std::string cmd = py + " -m venv " + venvPath;
+      if(std::system(cmd.c_str()) != 0)
+        return false;
+      cmd = venvPath + "/bin/pip install --quiet torch onnxmltools packaging numpy onnx";
+      if(std::system(cmd.c_str()) != 0)
+        return false;
+    }
+
+    std::string scriptPath = "/tmp/mgxconvert.py";
+    std::ofstream ofs(scriptPath);
+    ofs << PYTHON_SCRIPT;
+    ofs.close();
+
+    std::string cmd = venvPath + "/bin/python " + scriptPath + " --model " + modelPath + " --output " + outPath;
+    int ret = std::system(cmd.c_str());
+    return ret == 0;
+  }
+
+}  // namespace MGXConvert

--- a/cpp/neuralnet/mgxconvert.h
+++ b/cpp/neuralnet/mgxconvert.h
@@ -1,0 +1,7 @@
+#pragma once
+#include <string>
+
+namespace MGXConvert {
+bool convertRawToOnnx(const std::string& modelPath,
+                      const std::string& outPath);
+}

--- a/cpp/program/gtpconfig.cpp
+++ b/cpp/program/gtpconfig.cpp
@@ -539,6 +539,9 @@ string GTPConfig::makeConfig(
 #ifdef USE_ROCM_BACKEND
       replacement += "rocmDeviceToUseThread" + Global::intToString(i) + " = " + Global::intToString(deviceIdxs[i]) + "\n";
 #endif
+#ifdef USE_MGX_BACKEND
+      replacement += "mgxDeviceToUseThread" + Global::intToString(i) + " = " + Global::intToString(deviceIdxs[i]) + "\n";
+#endif
     }
     replace("$$MULTIPLE_GPUS", replacement);
   }

--- a/cpp/program/setup.cpp
+++ b/cpp/program/setup.cpp
@@ -20,6 +20,7 @@ std::vector<std::string> Setup::getBackendPrefixes() {
   prefixes.push_back("metal");
   prefixes.push_back("opencl");
   prefixes.push_back("rocm");
+  prefixes.push_back("mgx");
   prefixes.push_back("eigen");
   prefixes.push_back("dummybackend");
   return prefixes;
@@ -89,6 +90,8 @@ vector<NNEvaluator*> Setup::initializeNNEvaluators(
   string backendPrefix = "opencl";
   #elif defined(USE_ROCM_BACKEND)
   string backendPrefix = "rocm";
+  #elif defined(USE_MGX_BACKEND)
+  string backendPrefix = "mgx";
   #elif defined(USE_EIGEN_BACKEND)
   string backendPrefix = "eigen";
   #else


### PR DESCRIPTION
## Summary
- embed Python model converter inside C++ and generate ONNX via runtime virtualenv
- invoke embedded converter from MIGraphX backend before parsing ONNX
- adjust build scripts to include new converter source and drop Python linkage
- initialize converter's network layers from model config and install required Python packages
- remove external config JSON dependency by inlining minimal model config values in converter

## Testing
- `cmake ../cpp -DUSE_BACKEND=MGX` *(fails: Could not find a package configuration file provided by "migraphx" with any of the following names: migraphxConfig.cmake, migraphx-config.cmake)*

------
https://chatgpt.com/codex/tasks/task_e_689c294cafac8327b49f2c439e3dc7a0