### PR TITLE
Add ROCm and MIGraphX support for AMD GPU

### DIFF
--- a/cpp/neuralnet/migraphxbackend.cpp
+++ b/cpp/neuralnet/migraphxbackend.cpp
@@ -4,6 +4,8 @@
 #include "../neuralnet/modelversion.h"
 #include "../neuralnet/desc.h"
 #include "../neuralnet/sgfmetadata.h"
+#include "../neuralnet/activations.h"
+#include "../neuralnet/activations.h"
 
 #include "../core/fileutils.h"
 #include "../core/makedir.h"
@@ -36,6 +38,7 @@
 #include <cmath>
 #include <cstring>
 #include <mutex>
+#include <map>
 
 using namespace std;
 
@@ -63,8 +66,12 @@ using namespace std;
 //------------------------ MIGraphX Model Implementation ------------------------
 
 struct MIGraphXModel {
-    migraphx::program prog;
+    // Multiple compiled programs for different batch sizes
+    // Key: batch size, Value: compiled program
+    map<int, migraphx::program> progs;
     migraphx::target tgt;
+    // Sorted batch sizes for quick lookup
+    vector<int> batchSizes;
     
     int modelVersion;
     int maxBatchSize;
@@ -86,6 +93,18 @@ struct MIGraphXModel {
           numInputChannels(0), numInputGlobalChannels(0), numInputMetaChannels(0),
           numPolicyChannels(0), numValueChannels(3),
           numScoreValueChannels(0), numOwnershipChannels(0) {}
+    
+    // Find the best (smallest sufficient) batch size for the given actual batch
+    int getBestBatchSize(int actualBatch) const {
+        for(int bs : batchSizes) {
+            if(bs >= actualBatch) return bs;
+        }
+        return batchSizes.back();
+    }
+    
+    migraphx::program& getProgram(int batchSize) {
+        return progs.at(batchSize);
+    }
 };
 
 // Helper class to build MIGraphX graph
@@ -242,6 +261,11 @@ public:
                 auto unsqueeze_op = migraphx::make_op("unsqueeze", {{"axes", migraphx::value({0})}});
                 bias = main_module->add_instruction(unsqueeze_op, bias);
                 
+                // Explicit broadcast to match matmul output shape
+                auto matmulShape = matmul->get_shape().lens();
+                bias = main_module->add_instruction(
+                    migraphx::make_op("multibroadcast", {{"out_lens", matmulShape}}), bias);
+                
                 matmul = main_module->add_instruction(migraphx::make_op("add"), matmul, bias);
             }
         }
@@ -251,20 +275,59 @@ public:
     
     // Add activation
     migraphx::instruction_ref addActivation(migraphx::instruction_ref input, int activationType) {
-        if(activationType == 1) {  // GELU
-            return addGELU(input);
+        if(activationType == ACTIVATION_IDENTITY) {
+            return input;
         }
+        else if(activationType == ACTIVATION_RELU) {
+            return main_module->add_instruction(migraphx::make_op("relu"), input);
+        }
+        else if(activationType == ACTIVATION_MISH) {
+            return addMish(input);
+        }
+        else if(activationType == ACTIVATION_MISH_SCALE8) {
+            return addMishScale8(input);
+        }
+        // Fallback to relu
         return main_module->add_instruction(migraphx::make_op("relu"), input);
     }
     
-    // GELU activation
-    migraphx::instruction_ref addGELU(migraphx::instruction_ref input) {
-        vector<float> constData = {1.702f};
-        auto constLit = addLiteral(constData, {1, 1, 1, 1});
-        
-        auto scaled = main_module->add_instruction(migraphx::make_op("mul"), input, constLit);
-        auto sigmoid = main_module->add_instruction(migraphx::make_op("sigmoid"), scaled);
-        return main_module->add_instruction(migraphx::make_op("mul"), input, sigmoid);
+    // Mish activation: x * tanh(softplus(x)) = x * tanh(log(1 + exp(x)))
+    migraphx::instruction_ref addMish(migraphx::instruction_ref input) {
+        auto inputLens = input->get_shape().lens();
+        // softplus(x) = log(1 + exp(x))
+        auto exp_x = main_module->add_instruction(migraphx::make_op("exp"), input);
+        auto ones = broadcastScalar(1.0f, inputLens);
+        auto one_plus_exp = main_module->add_instruction(migraphx::make_op("add"), exp_x, ones);
+        auto softplus = main_module->add_instruction(migraphx::make_op("log"), one_plus_exp);
+        auto tanh_sp = main_module->add_instruction(migraphx::make_op("tanh"), softplus);
+        return main_module->add_instruction(migraphx::make_op("mul"), input, tanh_sp);
+    }
+    
+    // Mish-scale8 activation: x * tanh(softplus(clamp(8x, -, 30)))
+    // For x >= 2.5: tanh(softplus(20+)) ≈ 1, so result ≈ x (identity)
+    // For x < 2.5: standard mish with 8x scaling of softplus argument
+    migraphx::instruction_ref addMishScale8(migraphx::instruction_ref input) {
+        auto inputLens = input->get_shape().lens();
+        // scaled = 8 * x, clamped to max 30 to prevent exp overflow
+        auto eight = broadcastScalar(8.0f, inputLens);
+        auto scaled = main_module->add_instruction(migraphx::make_op("mul"), input, eight);
+        auto thirty = broadcastScalar(30.0f, inputLens);
+        scaled = main_module->add_instruction(migraphx::make_op("min"), scaled, thirty);
+        // softplus(scaled) = log(1 + exp(scaled))
+        auto exp_s = main_module->add_instruction(migraphx::make_op("exp"), scaled);
+        auto ones = broadcastScalar(1.0f, inputLens);
+        auto one_plus_exp = main_module->add_instruction(migraphx::make_op("add"), exp_s, ones);
+        auto softplus = main_module->add_instruction(migraphx::make_op("log"), one_plus_exp);
+        auto tanh_sp = main_module->add_instruction(migraphx::make_op("tanh"), softplus);
+        return main_module->add_instruction(migraphx::make_op("mul"), input, tanh_sp);
+    }
+    
+    // Helper: broadcast a scalar to the given shape
+    migraphx::instruction_ref broadcastScalar(float val, const vector<size_t>& targetLens) {
+        vector<size_t> onesShape(targetLens.size(), 1);
+        auto lit = addLiteral({val}, onesShape);
+        return main_module->add_instruction(
+            migraphx::make_op("multibroadcast", {{"out_lens", targetLens}}), lit);
     }
     
     // Add literal
@@ -372,6 +435,46 @@ public:
         return main_module->add_instruction(concat_op, inputs);
     }
     
+    // Global pooling producing 3 features per channel.
+    // For trunk/policy: [mean, mean*scale1, max]
+    // For value head:   [mean, mean*scale1, mean*scale2]
+    // Input: [batch, C, H, W], Output: [batch, C*3]
+    // Note: assumes full board (no mask), correct for standard play at nnXLen x nnYLen.
+    migraphx::instruction_ref addGPool(migraphx::instruction_ref input, bool isValueHead = false) {
+        float boardArea = (float)(nnXLen * nnYLen);
+        float sqrtBoardArea = sqrtf(boardArea);
+        float scale1Factor = (sqrtBoardArea - 14.0f) * 0.1f;
+        
+        // mean: [batch, C, H, W] -> [batch, C, 1, 1] -> [batch, C]
+        auto mean = addReduceMean(input, {2, 3});
+        mean = addSqueeze(mean, {2, 3});
+        
+        auto meanShape = mean->get_shape().lens();
+        
+        // scale1 = mean * scale1Factor
+        auto scale1Lit = addLiteral({scale1Factor}, {1, 1});
+        auto scale1Broadcast = main_module->add_instruction(
+            migraphx::make_op("multibroadcast", {{"out_lens", meanShape}}), scale1Lit);
+        auto scale1 = main_module->add_instruction(migraphx::make_op("mul"), mean, scale1Broadcast);
+        
+        migraphx::instruction_ref third;
+        if(isValueHead) {
+            // scale2 = mean * ((sqrtBoardArea - 14)^2 * 0.01 - 0.1)
+            float scale2Factor = (sqrtBoardArea - 14.0f) * (sqrtBoardArea - 14.0f) * 0.01f - 0.1f;
+            auto scale2Lit = addLiteral({scale2Factor}, {1, 1});
+            auto scale2Broadcast = main_module->add_instruction(
+                migraphx::make_op("multibroadcast", {{"out_lens", meanShape}}), scale2Lit);
+            third = main_module->add_instruction(migraphx::make_op("mul"), mean, scale2Broadcast);
+        } else {
+            // max: [batch, C, H, W] -> [batch, C, 1, 1] -> [batch, C]
+            auto maxVal = addReduceMax(input, {2, 3});
+            third = addSqueeze(maxVal, {2, 3});
+        }
+        
+        // Concat [mean, scale1, third] along axis 1 -> [batch, C*3]
+        return addConcat({mean, scale1, third}, 1);
+    }
+    
 };
 
 // Build residual block
@@ -477,22 +580,55 @@ static migraphx::instruction_ref buildResidualBlockStack(
             const NestedBottleneckResidualBlockDesc* blockDesc = static_cast<const NestedBottleneckResidualBlockDesc*>(blocks[i].second.get());
             trunk = buildNestedBottleneckResidualBlock(builder, trunk, *blockDesc);
         }
+        
     }
     
     return trunk;
 }
 
-// Build global pooling residual block - fallback to ordinary residual block
-// Full implementation requires careful handling of gpool mean/scale/max concatenation
+// Build global pooling residual block - full implementation
 static migraphx::instruction_ref buildGlobalPoolingResidualBlock(
     MIGraphXGraphBuilder& builder,
     migraphx::instruction_ref input,
     const GlobalPoolingResidualBlockDesc& blockDesc
 ) {
-    // For now, treat as ordinary residual block
-    // Full implementation would use gpoolConv, gpool pooling, and gpoolToBiasMul
-    (void)blockDesc;
-    return buildResidualBlock(builder, input, *(const ResidualBlockDesc*)&blockDesc);
+    auto residual = input;
+    
+    // preBN + preActivation
+    auto x = builder.addBatchNorm(input, blockDesc.preBN);
+    x = builder.addActivation(x, blockDesc.preActivation.activation);
+    
+    // Branch A: regular spatial conv
+    auto regularOut = builder.addConv(x, blockDesc.regularConv);
+    
+    // Branch B: global pooling conv
+    auto gpoolOut = builder.addConv(x, blockDesc.gpoolConv);
+    gpoolOut = builder.addBatchNorm(gpoolOut, blockDesc.gpoolBN);
+    gpoolOut = builder.addActivation(gpoolOut, blockDesc.gpoolActivation.activation);
+    
+    // Global pool: [batch, gpoolC, H, W] -> [batch, gpoolC*3]
+    auto gpoolFeatures = builder.addGPool(gpoolOut, false);
+    
+    // gpoolToBiasMul: [batch, gpoolC*3] -> [batch, regularC]
+    auto bias = builder.addMatMul(gpoolFeatures, blockDesc.gpoolToBiasMul);
+    
+    // Broadcast bias to spatial dims and add to regularOut
+    auto regularShape = regularOut->get_shape().lens();
+    auto biasUnsqueezed = builder.main_module->add_instruction(
+        migraphx::make_op("unsqueeze", {{"axes", migraphx::value(vector<int64_t>{2, 3})}}), bias);
+    auto biasBroadcast = builder.main_module->add_instruction(
+        migraphx::make_op("multibroadcast", {{"out_lens", regularShape}}), biasUnsqueezed);
+    regularOut = builder.main_module->add_instruction(migraphx::make_op("add"), regularOut, biasBroadcast);
+    
+    // midBN + midActivation
+    regularOut = builder.addBatchNorm(regularOut, blockDesc.midBN);
+    regularOut = builder.addActivation(regularOut, blockDesc.midActivation.activation);
+    
+    // finalConv
+    regularOut = builder.addConv(regularOut, blockDesc.finalConv);
+    
+    // Add residual
+    return builder.main_module->add_instruction(migraphx::make_op("add"), regularOut, residual);
 }
 
 // Build complete MIGraphX program from ModelDesc
@@ -517,13 +653,21 @@ static migraphx::program buildMIGraphXProgram(
     vector<size_t> inputShape = {(size_t)maxBatchSize, (size_t)numSpatialFeatures, (size_t)nnYLen, (size_t)nnXLen};
     vector<size_t> inputGlobalShape = {(size_t)maxBatchSize, (size_t)numGlobalFeatures};
     
-    auto inputSpatial = main_module->add_parameter("input_spatial", migraphx::shape(dataType, inputShape));
-    auto inputGlobal = main_module->add_parameter("input_global", migraphx::shape(dataType, inputGlobalShape));
+    // Input parameters are always float_type (host buffers are float).
+    // If using FP16, we convert to half inside the graph so MIGraphX handles conversion on GPU.
+    auto inputSpatial = main_module->add_parameter("input_spatial", migraphx::shape(migraphx::shape::float_type, inputShape));
+    auto inputGlobal = main_module->add_parameter("input_global", migraphx::shape(migraphx::shape::float_type, inputGlobalShape));
     
     // MIGraphX backend uses NCHW format only
     (void)useNHWC;  // Silently ignore NHWC setting
     
     MIGraphXGraphBuilder builder(main_module, dataType, maxBatchSize, nnXLen, nnYLen);
+    
+    // Convert inputs to computation type if using FP16
+    if(useFP16) {
+        inputSpatial = builder.addConvert(inputSpatial, dataType);
+        inputGlobal = builder.addConvert(inputGlobal, dataType);
+    }
     
     // Build trunk
     auto trunk = inputSpatial;
@@ -561,118 +705,90 @@ static migraphx::program buildMIGraphXProgram(
     trunk = builder.addBatchNorm(trunk, trunkDesc.trunkTipBN);
     trunk = builder.addActivation(trunk, trunkDesc.trunkTipActivation.activation);
     
-    // Policy head - full implementation with gpool
-    auto policy = trunk;
+    // ======== Policy Head ========
     const PolicyHeadDesc& policyDesc = modelDesc.policyHead;
     
+    migraphx::instruction_ref policy = trunk;
+    migraphx::instruction_ref policyPass = trunk; // will be overwritten
+    
     if(policyDesc.p1Conv.outChannels > 0) {
-        // p1Conv branch
+        // p1Conv branch (spatial policy)
         auto p1Conv = builder.addConv(trunk, policyDesc.p1Conv);
         
-        // g1Conv branch for global pooling (simplified - just use mean)
+        // g1Conv branch for global pooling
         auto g1Conv = builder.addConv(trunk, policyDesc.g1Conv);
         g1Conv = builder.addBatchNorm(g1Conv, policyDesc.g1BN);
         g1Conv = builder.addActivation(g1Conv, policyDesc.g1Activation.activation);
         
-        // Global pool g1Conv
-        auto gpool = builder.addReduceMean(g1Conv, {2, 3});
-        gpool = builder.addSqueeze(gpool, {2, 3});
+        // Global pool: [batch, g1C, H, W] -> [batch, g1C*3]
+        auto gpool = builder.addGPool(g1Conv, false);
         
-        // gpoolToBiasMul - only if weights are available and dimensions match
-        int gpoolChannels = policyDesc.g1Conv.outChannels;
-        if(policyDesc.gpoolToBiasMul.inChannels == gpoolChannels && !policyDesc.gpoolToBiasMul.weights.empty()) {
-            vector<size_t> gpoolWeightShape = {(size_t)policyDesc.gpoolToBiasMul.inChannels, (size_t)policyDesc.gpoolToBiasMul.outChannels};
-            auto gpoolWeights = builder.addLiteral(policyDesc.gpoolToBiasMul.weights, gpoolWeightShape);
-            auto gpoolBias = main_module->add_instruction(migraphx::make_op("dot"), gpool, gpoolWeights);
-            
-            // Broadcast and add to p1Conv
-            auto p1Shape = p1Conv->get_shape().lens();
-            auto biasUnsqueezed = main_module->add_instruction(
-                migraphx::make_op("unsqueeze", {{"axes", migraphx::value(vector<int64_t>{2, 3})}}), gpoolBias);
-            auto biasBroadcast = main_module->add_instruction(
-                migraphx::make_op("multibroadcast", {{"out_lens", p1Shape}}), biasUnsqueezed);
-            policy = main_module->add_instruction(migraphx::make_op("add"), p1Conv, biasBroadcast);
-        } else {
-            policy = p1Conv;
-        }
+        // gpoolToBiasMul: [batch, g1C*3] -> [batch, p1C] bias
+        auto gpoolBias = builder.addMatMul(gpool, policyDesc.gpoolToBiasMul);
+        
+        // Broadcast bias and add to p1Conv
+        auto p1Shape = p1Conv->get_shape().lens();
+        auto biasUnsqueezed = main_module->add_instruction(
+            migraphx::make_op("unsqueeze", {{"axes", migraphx::value(vector<int64_t>{2, 3})}}), gpoolBias);
+        auto biasBroadcast = main_module->add_instruction(
+            migraphx::make_op("multibroadcast", {{"out_lens", p1Shape}}), biasUnsqueezed);
+        policy = main_module->add_instruction(migraphx::make_op("add"), p1Conv, biasBroadcast);
         
         policy = builder.addBatchNorm(policy, policyDesc.p1BN);
         policy = builder.addActivation(policy, policyDesc.p1Activation.activation);
+        
+        // p2Conv -> spatial policy logits
+        if(policyDesc.p2Conv.outChannels > 0) {
+            policy = builder.addConv(policy, policyDesc.p2Conv);
+        }
+        
+        // Flatten spatial policy: [batch, numPolicyChannels, H, W] -> [batch, numPolicyChannels*H*W]
+        policy = builder.addFlatten(policy);
+        
+        // Pass policy (separate path from spatial, uses same gpool)
+        // gpoolToPassMul: [batch, g1C*3] -> passHidden
+        policyPass = builder.addMatMul(gpool, policyDesc.gpoolToPassMul, &policyDesc.gpoolToPassBias);
+        policyPass = builder.addActivation(policyPass, policyDesc.passActivation.activation);
+        
+        // gpoolToPassMul2: passHidden -> [batch, numPolicyChannels] (for modelVersion >= 15)
+        if(policyDesc.gpoolToPassMul2.outChannels > 0) {
+            policyPass = builder.addMatMul(policyPass, policyDesc.gpoolToPassMul2);
+        }
+    } else {
+        policy = builder.addFlatten(trunk);
+        // Zero pass policy fallback
+        vector<float> zeroPass(modelDesc.numPolicyChannels, 0.0f);
+        policyPass = builder.addLiteral(zeroPass, {1, (size_t)modelDesc.numPolicyChannels});
+        policyPass = main_module->add_instruction(
+            migraphx::make_op("multibroadcast", {{"out_lens", vector<size_t>{(size_t)maxBatchSize, (size_t)modelDesc.numPolicyChannels}}}), policyPass);
     }
     
-    if(policyDesc.p2Conv.outChannels > 0) {
-        policy = builder.addConv(policy, policyDesc.p2Conv);
-    }
-    
-    // Flatten policy
-    policy = builder.addFlatten(policy);
-    
-    // Value head - full implementation
-    auto value = trunk;
+    // ======== Value Head ========
     const ValueHeadDesc& valueDesc = modelDesc.valueHead;
     
-    // v1Conv output for both value and ownership branches
-    migraphx::instruction_ref v1Out = value;
+    // v1Conv + v1BN + v1Activation
+    auto v1Out = builder.addConv(trunk, valueDesc.v1Conv);
+    v1Out = builder.addBatchNorm(v1Out, valueDesc.v1BN);
+    v1Out = builder.addActivation(v1Out, valueDesc.v1Activation.activation);
     
-    if(valueDesc.v1Conv.outChannels > 0) {
-        v1Out = builder.addConv(v1Out, valueDesc.v1Conv);
-        v1Out = builder.addBatchNorm(v1Out, valueDesc.v1BN);
-        v1Out = builder.addActivation(v1Out, valueDesc.v1Activation.activation);
-    }
+    // Ownership branch: v1Out -> vOwnershipConv -> flatten (no tanh - matches CUDA backend)
+    auto ownership = builder.addConv(v1Out, valueDesc.vOwnershipConv);
+    ownership = builder.addFlatten(ownership);
     
-    // Ownership branch
-    migraphx::instruction_ref ownership = v1Out;
-    if(valueDesc.vOwnershipConv.outChannels > 0) {
-        ownership = builder.addConv(ownership, valueDesc.vOwnershipConv);
-        ownership = builder.addFlatten(ownership);
-        ownership = builder.addTanh(ownership);
-    } else {
-        ownership = builder.addFlatten(ownership);
-        int v1Channels = valueDesc.v1Conv.outChannels;
-        vector<float> oWeights(v1Channels * nnXLen * nnYLen, 0.0f);
-        for(int i = 0; i < v1Channels; i++) {
-            oWeights[i * nnXLen * nnYLen + (i % (nnXLen * nnYLen))] = 0.01f;
-        }
-        auto oW = builder.addLiteral(oWeights, {(size_t)v1Channels, (size_t)(nnXLen * nnYLen)});
-        ownership = main_module->add_instruction(migraphx::make_op("dot"), ownership, oW);
-        ownership = builder.addTanh(ownership);
-    }
+    // Value branch: v1Out -> GPool (value head style) -> v2Mul + v2Bias + v2Activation -> v3Mul + v3Bias
+    auto vGpool = builder.addGPool(v1Out, true);  // value head: mean, scale1, scale2
     
-    // Value branch - simplified implementation using direct projection
-    value = v1Out;
+    auto v2 = builder.addMatMul(vGpool, valueDesc.v2Mul, &valueDesc.v2Bias);
+    v2 = builder.addActivation(v2, valueDesc.v2Activation.activation);
     
-    // Global pool v1Out
-    auto vGpool = builder.addReduceMean(value, {2, 3});
-    vGpool = builder.addSqueeze(vGpool, {2, 3});
+    auto valueOut = builder.addMatMul(v2, valueDesc.v3Mul, &valueDesc.v3Bias);
     
-    int v1Channels = valueDesc.v1Conv.outChannels;
+    // Score value branch: same v2 -> sv3Mul + sv3Bias
+    auto scoreValue = builder.addMatMul(v2, valueDesc.sv3Mul, &valueDesc.sv3Bias);
     
-    // Simplified value projection to 3 outputs (win/loss/noresult)
-    vector<float> vWeights(v1Channels * 3, 0.0f);
-    for(int i = 0; i < v1Channels; i++) {
-        vWeights[i * 3 + 0] = 0.1f;  // win
-        vWeights[i * 3 + 1] = 0.1f;  // loss
-        vWeights[i * 3 + 2] = 0.05f; // no result
-    }
-    auto vW = builder.addLiteral(vWeights, {(size_t)v1Channels, 3});
-    auto valueOut = main_module->add_instruction(migraphx::make_op("dot"), vGpool, vW);
-    
-    // Score value - simplified to 6 outputs
-    vector<float> svWeights(v1Channels * 6, 0.0f);
-    for(int i = 0; i < v1Channels; i++) {
-        svWeights[i * 6 + 0] = 0.1f;  // score mean
-        svWeights[i * 6 + 1] = 0.05f; // score mean sq
-        svWeights[i * 6 + 2] = 0.1f;  // lead
-        svWeights[i * 6 + 3] = 0.0f;  // var time left
-        svWeights[i * 6 + 4] = 0.0f;  // shortterm winloss error
-        svWeights[i * 6 + 5] = 0.0f;  // shortterm score error
-    }
-    auto svW = builder.addLiteral(svWeights, {(size_t)v1Channels, 6});
-    auto scoreValue = main_module->add_instruction(migraphx::make_op("dot"), vGpool, svW);
-    
-    // Set outputs
+    // Set outputs: policy, policyPass, value, scoreValue, ownership
     if(modelDesc.modelVersion >= 2) {
-        main_module->add_return({policy, valueOut, scoreValue, ownership});
+        main_module->add_return({policy, policyPass, valueOut, scoreValue, ownership});
     } else {
         main_module->add_return({policy, valueOut});
     }
@@ -817,6 +933,21 @@ void freeComputeContext(ComputeContext* computeContext) {
 // Static mutex for cache operations
 static mutex migraphxCacheMutex;
 
+// Generate batch sizes to compile for MIGraphX (no dynamic batch support).
+static vector<int> generateBatchSizes(int maxBatchSize) {
+    vector<int> candidates = {4, 8, 16, 24, 32, 40, 64};
+    
+    // Keep only sizes <= maxBatchSize, always include maxBatchSize itself
+    vector<int> sizes;
+    for(int s : candidates) {
+        if(s <= maxBatchSize)
+            sizes.push_back(s);
+    }
+    if(sizes.empty() || sizes.back() != maxBatchSize)
+        sizes.push_back(maxBatchSize);
+    return sizes;
+}
+
 // Generate cache file path
 static string getCacheFilePath(
     const string& homeDataDir,
@@ -873,7 +1004,7 @@ ComputeHandle* createComputeHandle(
     handle->nnXLen = ctx->nnXLen;
     handle->nnYLen = ctx->nnYLen;
     
-    bool useFP16 = (ctx->useFP16Mode == enabled_t::True);
+    bool useFP16 = (ctx->useFP16Mode == enabled_t::True || ctx->useFP16Mode == enabled_t::Auto);
     bool useNHWC = (ctx->useNHWCMode == enabled_t::True);
     
     // MIGraphX backend only supports NCHW format
@@ -898,89 +1029,96 @@ ComputeHandle* createComputeHandle(
     handle->model->numScoreValueChannels = model->modelDesc.numScoreValueChannels;
     handle->model->numOwnershipChannels = model->modelDesc.numOwnershipChannels;
     
-    // Generate cache file path
-    string cacheFile = getCacheFilePath(
-        ctx->homeDataDir,
-        model->modelDesc,
-        ctx->nnXLen,
-        ctx->nnYLen,
-        maxBatchSize,
-        useFP16,
-        useNHWC,
-        requireExactNNLen
-    );
+    // Generate batch sizes to compile
+    vector<int> batchSizesToCompile = generateBatchSizes(maxBatchSize);
+    handle->model->batchSizes = batchSizesToCompile;
+    handle->model->tgt = migraphx::make_target("gpu");
     
-    bool cacheLoaded = false;
-    
-    // Try to load from cache
     lock_guard<mutex> cacheLock(migraphxCacheMutex);
     
-    if(FileUtils::exists(cacheFile)) {
-        try {
-            if(logger) {
-                logger->write("MIGraphX: Loading compiled program from cache: " + cacheFile);
+    for(int bs : batchSizesToCompile) {
+        // Generate cache file path for this batch size
+        string cacheFile = getCacheFilePath(
+            ctx->homeDataDir,
+            model->modelDesc,
+            ctx->nnXLen,
+            ctx->nnYLen,
+            bs,
+            useFP16,
+            useNHWC,
+            requireExactNNLen
+        );
+        
+        bool cacheLoaded = false;
+        
+        // Try to load from cache
+        if(FileUtils::exists(cacheFile)) {
+            try {
+                if(logger) {
+                    logger->write("MIGraphX: Loading compiled program from cache (batch " + Global::intToString(bs) + "): " + cacheFile);
+                }
+                cout << "MIGraphX: Loading batch " << bs << " from cache..." << endl;
+                
+                handle->model->progs[bs] = migraphx::load(cacheFile);
+                cacheLoaded = true;
+                
+                cout << "MIGraphX: Batch " << bs << " loaded! (FP16: " << (useFP16 ? "yes" : "no") << ")" << endl;
+            } catch(const exception& e) {
+                if(logger) {
+                    logger->write(string("MIGraphX: Cache load failed for batch ") + Global::intToString(bs) + ": " + e.what());
+                }
+                cout << "MIGraphX: Cache load failed for batch " << bs << ", rebuilding..." << endl;
             }
-            cout << "MIGraphX: Loading compiled program from cache..." << endl;
+        }
+        
+        if(!cacheLoaded) {
+            cout << "MIGraphX: Building model (version " << model->modelDesc.modelVersion << ")..." << endl;
+            cout << "  Board size: " << ctx->nnXLen << "x" << ctx->nnYLen << endl;
+            cout << "  Batch size: " << bs << endl;
+            cout << "  FP16: " << (useFP16 ? "yes" : "no") << endl;
+            cout << "  NHWC: " << (useNHWC ? "yes" : "no") << endl;
+            cout << "  Trunk channels: " << model->modelDesc.trunk.trunkNumChannels << endl;
+            cout << "  Num blocks: " << model->modelDesc.trunk.numBlocks << endl;
             
-            // Load compiled program using MIGraphX C++ API
-            handle->model->prog = migraphx::load(cacheFile);
-            handle->model->tgt = migraphx::make_target("gpu");
-            cacheLoaded = true;
+            handle->model->progs[bs] = buildMIGraphXProgram(
+                model->modelDesc,
+                bs,
+                ctx->nnXLen,
+                ctx->nnYLen,
+                useFP16,
+                useNHWC
+            );
             
-            cout << "MIGraphX: Cache loaded successfully! (FP16: " << (useFP16 ? "yes" : "no") << ")" << endl;
-        } catch(const exception& e) {
-            if(logger) {
-                logger->write(string("MIGraphX: Cache load failed: ") + e.what());
+            cout << "MIGraphX: Compiling batch " << bs << "..." << endl;
+            migraphx::compile_options compile_opts;
+            compile_opts.offload_copy = true;
+            
+            handle->model->progs[bs].compile(handle->model->tgt, compile_opts);
+            
+            cout << "MIGraphX: Batch " << bs << " compiled!" << endl;
+            
+            // Save to cache
+            try {
+                if(logger) {
+                    logger->write("MIGraphX: Saving compiled program to cache (batch " + Global::intToString(bs) + "): " + cacheFile);
+                }
+                migraphx::save(handle->model->progs[bs], cacheFile);
+                cout << "MIGraphX: Batch " << bs << " cached!" << endl;
+            } catch(const exception& e) {
+                if(logger) {
+                    logger->write(string("MIGraphX: Cache save failed: ") + e.what());
+                }
+                cout << "MIGraphX: Cache save failed: " << e.what() << endl;
             }
-            cout << "MIGraphX: Cache load failed, rebuilding..." << endl;
         }
     }
     
-    if(!cacheLoaded) {
-        cout << "MIGraphX: Building model (version " << model->modelDesc.modelVersion << ")..." << endl;
-        cout << "  Board size: " << ctx->nnXLen << "x" << ctx->nnYLen << endl;
-        cout << "  Batch size: " << maxBatchSize << endl;
-        cout << "  FP16: " << (useFP16 ? "yes" : "no") << endl;
-        cout << "  NHWC: " << (useNHWC ? "yes" : "no") << endl;
-        cout << "  Trunk channels: " << model->modelDesc.trunk.trunkNumChannels << endl;
-        cout << "  Num blocks: " << model->modelDesc.trunk.numBlocks << endl;
-        
-        handle->model->prog = buildMIGraphXProgram(
-            model->modelDesc,
-            maxBatchSize,
-            ctx->nnXLen,
-            ctx->nnYLen,
-            useFP16,
-            useNHWC
-        );
-        
-        cout << "MIGraphX: Compiling program..." << endl;
-        migraphx::compile_options compile_opts;
-        compile_opts.offload_copy = true;
-        
-        handle->model->tgt = migraphx::make_target("gpu");
-        handle->model->prog.compile(handle->model->tgt, compile_opts);
-        
-        cout << "MIGraphX: Compilation complete!" << endl;
-        
-        // Save to cache using MIGraphX C++ API
-        try {
-            if(logger) {
-                logger->write("MIGraphX: Saving compiled program to cache: " + cacheFile);
-            }
-            cout << "MIGraphX: Saving to cache..." << endl;
-            
-            // Save compiled program using MIGraphX C++ API
-            migraphx::save(handle->model->prog, cacheFile);
-            
-            cout << "MIGraphX: Cache saved successfully!" << endl;
-        } catch(const exception& e) {
-            if(logger) {
-                logger->write(string("MIGraphX: Cache save failed: ") + e.what());
-            }
-            cout << "MIGraphX: Cache save failed: " << e.what() << endl;
-        }
+    cout << "MIGraphX: All " << batchSizesToCompile.size() << " batch sizes ready: ";
+    for(size_t i = 0; i < batchSizesToCompile.size(); i++) {
+        if(i > 0) cout << ", ";
+        cout << batchSizesToCompile[i];
     }
+    cout << endl;
     
     return reinterpret_cast<ComputeHandle*>(handle);
 }
@@ -1105,29 +1243,105 @@ void getOutput(
         );
     }
     
-    // Run inference
-    int maxBatchSize = handle->model->maxBatchSize;
+    // Run inference - pick the smallest compiled batch size that fits
+    int bestBatchSize = handle->model->getBestBatchSize(batchSize);
     migraphx::parameter_map params;
     
+    // Always use float_type for input shapes - host buffers are float, graph handles conversion
     migraphx::shape input_shape(
-        handle->model->useFP16 ? migraphx::shape::half_type : migraphx::shape::float_type,
-        {(size_t)maxBatchSize, (size_t)numSpatialFeatures, (size_t)nnYLen, (size_t)nnXLen}
+        migraphx::shape::float_type,
+        {(size_t)bestBatchSize, (size_t)numSpatialFeatures, (size_t)nnYLen, (size_t)nnXLen}
     );
     params["input_spatial"] = migraphx::argument(input_shape, buffers->userInputBuffer.data());
     
     migraphx::shape global_shape(
-        handle->model->useFP16 ? migraphx::shape::half_type : migraphx::shape::float_type,
-        {(size_t)maxBatchSize, (size_t)numGlobalFeatures}
+        migraphx::shape::float_type,
+        {(size_t)bestBatchSize, (size_t)numGlobalFeatures}
     );
     params["input_global"] = migraphx::argument(global_shape, buffers->userInputGlobalBuffer.data());
     
-    auto results = handle->model->prog.eval(params);
+    auto results = handle->model->getProgram(bestBatchSize).eval(params);
     
-    // Process outputs
+    // Extract results from MIGraphX eval into buffers
+    // Output order for modelVersion >= 2: policy, policyPass, value, scoreValue, ownership
+    int numPolicyChannels = handle->model->numPolicyChannels;
+    size_t policySize = (size_t)numPolicyChannels * nnXLen * nnYLen;
+    int numValueChannels = handle->model->numValueChannels;
+    int numScoreValueChannels = handle->model->numScoreValueChannels;
+    size_t ownershipSize = (size_t)nnXLen * nnYLen;
+    
+    // Policy: [maxBatchSize, numPolicyChannels * H * W]
+    if(results.size() > 0) {
+        results[0].visit([&](auto output) {
+            for(int row = 0; row < batchSize; row++) {
+                for(size_t i = 0; i < policySize; i++) {
+                    buffers->policyResults[row * policySize + i] = static_cast<float>(output[row * policySize + i]);
+                }
+            }
+        });
+    }
+    
+    if(modelVersion >= 2) {
+        // Policy pass: [maxBatchSize, numPolicyChannels]
+        if(results.size() > 1) {
+            results[1].visit([&](auto output) {
+                for(int row = 0; row < batchSize; row++) {
+                    for(int i = 0; i < numPolicyChannels; i++) {
+                        buffers->policyPassResults[row * numPolicyChannels + i] = static_cast<float>(output[row * numPolicyChannels + i]);
+                    }
+                }
+            });
+        }
+        
+        // Value: [maxBatchSize, numValueChannels]
+        if(results.size() > 2) {
+            results[2].visit([&](auto output) {
+                for(int row = 0; row < batchSize; row++) {
+                    for(int i = 0; i < numValueChannels; i++) {
+                        buffers->valueResults[row * numValueChannels + i] = static_cast<float>(output[row * numValueChannels + i]);
+                    }
+                }
+            });
+        }
+        
+        // Score value: [maxBatchSize, numScoreValueChannels]
+        if(results.size() > 3) {
+            results[3].visit([&](auto output) {
+                for(int row = 0; row < batchSize; row++) {
+                    for(int i = 0; i < numScoreValueChannels; i++) {
+                        buffers->scoreValueResults[row * numScoreValueChannels + i] = static_cast<float>(output[row * numScoreValueChannels + i]);
+                    }
+                }
+            });
+        }
+        
+        // Ownership: [maxBatchSize, H * W]
+        if(results.size() > 4) {
+            results[4].visit([&](auto output) {
+                for(int row = 0; row < batchSize; row++) {
+                    for(size_t i = 0; i < ownershipSize; i++) {
+                        buffers->ownershipResults[row * ownershipSize + i] = static_cast<float>(output[row * ownershipSize + i]);
+                    }
+                }
+            });
+        }
+    } else {
+        // Value: [maxBatchSize, numValueChannels]
+        if(results.size() > 1) {
+            results[1].visit([&](auto output) {
+                for(int row = 0; row < batchSize; row++) {
+                    for(int i = 0; i < numValueChannels; i++) {
+                        buffers->valueResults[row * numValueChannels + i] = static_cast<float>(output[row * numValueChannels + i]);
+                    }
+                }
+            });
+        }
+    }
+    
+    // Process outputs per row
     assert(outputs.size() == (size_t)batchSize);
     
     float policyProbsTmp[NNPos::MAX_NN_POLICY_SIZE];
-    int numPolicyChannels = handle->model->numPolicyChannels;
     
     for(int row = 0; row < batchSize; row++) {
         NNOutput* output = outputs[row];
@@ -1136,7 +1350,7 @@ void getOutput(
         float policyOptimism = (float)inputBufs[row]->policyOptimism;
         
         const float* policyPassSrcBuf = buffers->policyPassResults.data() + row * numPolicyChannels;
-        const float* policySrcBuf = buffers->policyResults.data() + row * numPolicyChannels * nnXLen * nnYLen;
+        const float* policySrcBuf = buffers->policyResults.data() + row * policySize;
         float* policyProbs = output->policyProbs;
         
         if(numPolicyChannels == 2 || (numPolicyChannels == 4 && modelVersion >= 16)) {
@@ -1157,25 +1371,58 @@ void getOutput(
             policyProbs[nnXLen * nnYLen] = policyPassSrcBuf[0];
         }
         
-        int numValueChannels = handle->model->numValueChannels;
         assert(numValueChannels == 3);
         output->whiteWinProb = buffers->valueResults[row * numValueChannels];
         output->whiteLossProb = buffers->valueResults[row * numValueChannels + 1];
         output->whiteNoResultProb = buffers->valueResults[row * numValueChannels + 2];
         
-        if(modelVersion >= 2 && handle->model->numScoreValueChannels > 0) {
-            output->whiteScoreMean = buffers->scoreValueResults[row * handle->model->numScoreValueChannels];
-            output->whiteScoreMeanSq = buffers->scoreValueResults[row * handle->model->numScoreValueChannels + 1];
-            output->whiteLead = buffers->scoreValueResults[row * handle->model->numScoreValueChannels + 2];
+        if(output->whiteOwnerMap != NULL) {
+            const float* ownershipSrcBuf = buffers->ownershipResults.data() + row * ownershipSize;
+            assert(handle->model->numOwnershipChannels == 1);
+            SymmetryHelpers::copyOutputsWithSymmetry(ownershipSrcBuf, output->whiteOwnerMap, 1, nnYLen, nnXLen, inputBufs[row]->symmetry);
+        }
+        
+        if(modelVersion >= 9) {
+            assert(numScoreValueChannels == 6);
+            output->whiteScoreMean = buffers->scoreValueResults[row * numScoreValueChannels];
+            output->whiteScoreMeanSq = buffers->scoreValueResults[row * numScoreValueChannels + 1];
+            output->whiteLead = buffers->scoreValueResults[row * numScoreValueChannels + 2];
+            output->varTimeLeft = buffers->scoreValueResults[row * numScoreValueChannels + 3];
+            output->shorttermWinlossError = buffers->scoreValueResults[row * numScoreValueChannels + 4];
+            output->shorttermScoreError = buffers->scoreValueResults[row * numScoreValueChannels + 5];
+        } else if(modelVersion >= 8) {
+            assert(numScoreValueChannels == 4);
+            output->whiteScoreMean = buffers->scoreValueResults[row * numScoreValueChannels];
+            output->whiteScoreMeanSq = buffers->scoreValueResults[row * numScoreValueChannels + 1];
+            output->whiteLead = buffers->scoreValueResults[row * numScoreValueChannels + 2];
+            output->varTimeLeft = buffers->scoreValueResults[row * numScoreValueChannels + 3];
+            output->shorttermWinlossError = 0.0f;
+            output->shorttermScoreError = 0.0f;
+        } else if(modelVersion >= 4) {
+            assert(numScoreValueChannels == 2);
+            output->whiteScoreMean = buffers->scoreValueResults[row * numScoreValueChannels];
+            output->whiteScoreMeanSq = buffers->scoreValueResults[row * numScoreValueChannels + 1];
+            output->whiteLead = output->whiteScoreMean;
+            output->varTimeLeft = 0.0f;
+            output->shorttermWinlossError = 0.0f;
+            output->shorttermScoreError = 0.0f;
+        } else if(modelVersion >= 3) {
+            assert(numScoreValueChannels == 1);
+            output->whiteScoreMean = buffers->scoreValueResults[row * numScoreValueChannels];
+            output->whiteScoreMeanSq = output->whiteScoreMean * output->whiteScoreMean;
+            output->whiteLead = output->whiteScoreMean;
+            output->varTimeLeft = 0.0f;
+            output->shorttermWinlossError = 0.0f;
+            output->shorttermScoreError = 0.0f;
         } else {
             output->whiteScoreMean = 0.0f;
             output->whiteScoreMeanSq = 1.0f;
             output->whiteLead = 0.0f;
+            output->varTimeLeft = 0.0f;
+            output->shorttermWinlossError = 0.0f;
+            output->shorttermScoreError = 0.0f;
         }
         
-        output->varTimeLeft = 1.0f;
-        output->shorttermWinlossError = 0.0f;
-        output->shorttermScoreError = 0.0f;
         output->policyOptimismUsed = policyOptimism;
     }
 }

--- a/cpp/neuralnet/rocmbackend.cpp
+++ b/cpp/neuralnet/rocmbackend.cpp
@@ -253,6 +253,7 @@ struct ConvLayer {
   const int outChannels;
   const int nnXLen;
   const int nnYLen;
+  const int maxBatchSize;
   const bool usingFP16;
   ByBatchSizeView<miopenTensorDescriptor_t> inputDescriptors;
   ByBatchSizeView<miopenTensorDescriptor_t> outputDescriptors;
@@ -260,6 +261,7 @@ struct ConvLayer {
   miopenConvolutionDescriptor_t convolutionDescriptor;
   ByBatchSize<miopenConvSolution_t>* convolutionAlgorithms; //array of one for each batch size
   void* filterBuf;
+  void* accumBuf; // Pre-allocated buffer for residual accumulation (miopenConvolutionForwardImmediate has no beta)
 
   ConvLayer() = delete;
   ConvLayer(const ConvLayer&) = delete;
@@ -287,6 +289,7 @@ struct ConvLayer {
     outChannels(desc->outChannels),
     nnXLen(manager->nnXLen),
     nnYLen(manager->nnYLen),
+    maxBatchSize(manager->maxBatchSize),
     usingFP16(useFP16)
   {
     int convYSize = desc->convYSize;
@@ -395,10 +398,20 @@ struct ConvLayer {
     }
     else
       CudaUtils::mallocAndCopyToDevice(name,desc->weights,filterBuf,useFP16);
+
+    // Pre-allocate buffer for accumulate mode (residual skip connections).
+    // miopenConvolutionForwardImmediate does not support alpha/beta unlike cuDNN,
+    // so we need to save the output before conv and add it back afterwards.
+    {
+      int elemSize = usingFP16 ? sizeof(half_t) : sizeof(float);
+      size_t accumBytes = (size_t)maxBatchSize * outChannels * nnXLen * nnYLen * elemSize;
+      CUDA_ERR(name.c_str(), hipMalloc(&accumBuf, accumBytes));
+    }
   }
 
   ~ConvLayer() {
     hipFree(filterBuf);
+    hipFree(accumBuf);
     miopenDestroyTensorDescriptor(filterDescriptor);
     miopenDestroyConvolutionDescriptor(convolutionDescriptor);
     delete convolutionAlgorithms;
@@ -432,14 +445,11 @@ struct ConvLayer {
   ) const {
     // miopenConvolutionForwardImmediate does NOT support alpha/beta (unlike cuDNN).
     // When accumulate=true, we need: outputBuf = conv(inputBuf) + outputBuf (residual skip connection).
-    // So we save outputBuf first, run conv (which overwrites outputBuf), then add saved data back.
-    void* residualBuf = nullptr;
+    // Save outputBuf content to pre-allocated accumBuf, run conv, then add back.
     if(accumulate) {
       int elemSize = usingFP16 ? sizeof(half) : sizeof(float);
-      size_t outputElems = (size_t)batchSize * outChannels * nnXLen * nnYLen;
-      size_t outputBytes = outputElems * elemSize;
-      CUDA_ERR(name.c_str(), hipMalloc(&residualBuf, outputBytes));
-      CUDA_ERR(name.c_str(), hipMemcpy(residualBuf, outputBuf, outputBytes, hipMemcpyDeviceToDevice));
+      size_t outputBytes = (size_t)batchSize * outChannels * nnXLen * nnYLen * elemSize;
+      CUDA_ERR(name.c_str(), hipMemcpyAsync(accumBuf, outputBuf, outputBytes, hipMemcpyDeviceToDevice));
     }
 
     CUDNN_ERR(name.c_str(), miopenConvolutionForwardImmediate(
@@ -457,12 +467,11 @@ struct ConvLayer {
     ));
 
     if(accumulate) {
-      size_t outputElems = (size_t)batchSize * outChannels * nnXLen * nnYLen;
+      int outputElems = (int)((size_t)batchSize * outChannels * nnXLen * nnYLen);
       if(usingFP16)
-        customCudaAddTensorsInplace((half*)outputBuf, (const half*)residualBuf, (int)outputElems);
+        customCudaAddTensorsInplace((half*)outputBuf, (const half*)accumBuf, outputElems);
       else
-        customCudaAddTensorsInplace((float*)outputBuf, (const float*)residualBuf, (int)outputElems);
-      CUDA_ERR(name.c_str(), hipFree(residualBuf));
+        customCudaAddTensorsInplace((float*)outputBuf, (const float*)accumBuf, outputElems);
     }
   }
 

--- a/cpp/program/setup.cpp
+++ b/cpp/program/setup.cpp
@@ -147,7 +147,7 @@ vector<NNEvaluator*> Setup::initializeNNEvaluators(
         requireExactNNLen = cfg.getBool("requireMaxBoardSize");
     }
 
-    bool inputsUseNHWC = backendPrefix == "opencl" || backendPrefix == "trt" || backendPrefix == "metal" || backendPrefix == "rocm" ? false : true;
+    bool inputsUseNHWC = backendPrefix == "opencl" || backendPrefix == "trt" || backendPrefix == "metal" || backendPrefix == "rocm" || backendPrefix == "mgx" ? false : true;
     if(cfg.contains(backendPrefix+"InputsUseNHWC"+idxStr))
       inputsUseNHWC = cfg.getBool(backendPrefix+"InputsUseNHWC"+idxStr);
     else if(cfg.contains("inputsUseNHWC"+idxStr))


### PR DESCRIPTION
All test passed, we can merge it to main branch!

Binary release has been published here: https://github.com/Looong01/KataGo-Multi-backends/releases

## Background
This PR summarizes all commits by `Looong01` on the `AMD_GPU` branch from `2025-07-28` to `2026-03-16` (`23` commits total: `18` non-merge + `5` merge), focused on introducing and refining ROCm backend support in KataGo, plus the new MIGraphX backend added on the `MIGraphX` branch.

## Key Changes — ROCm Backend
- Added core ROCm backend implementation and utility files: rocmbackend.cpp, `rocmhelpers.hip`, `rocmutils.*`, `rocmincludes.h`, `rocmerrorcheck.h`.
- Integrated `USE_ROCM_BACKEND` into startup and config flow (`setup/benchmark/gtpconfig`) for proper backend detection and config generation.
- Expanded ROCm build logic in CMakeLists.txt: HIP compiler setup, architecture/FP16 detection, ROCm package lookup, and fallback linking.
- Added Windows ROCm build support (`HIP_PATH/ROCM_PATH`, clang toolchain handling, Windows library search paths).
- Iteratively improved rocmbackend.cpp with Convlayer method updates, performance tuning, and bug fixes.
- Introduced and then removed experimental `rocmbackend_new.cpp` after merging validated changes into the main backend path.
- Updated docs and sample configs (README / Compiling / `cpp/configs/*`) with ROCm instructions and `rocmDeviceToUse*`, `rocmUseFP16` examples.
- Regularly merged upstream `lightvector:master` to reduce branch drift.

### Critical Bug Fix: ConvLayer accumulate (residual skip connections)
- **Root cause**: `miopenConvolutionForwardImmediate` does **not** support `alpha`/`beta` parameters (unlike cuDNN's `cudnnConvolutionForward`). The original code set `beta = accumulate ? 1.0 : 0.0` but this value was never passed to the MIOpen API, causing all residual skip connections to be silently dropped — the neural network output was effectively garbage.
- **Fix**: When `accumulate=true`, save the output buffer (trunk) to a pre-allocated `accumBuf` via `hipMemcpyAsync` (Device-to-Device), run convolution (which overwrites the output buffer), then add the saved residual back using a new `customCudaAddTensorsInplace` GPU kernel. All operations stay in VRAM with zero CPU-side data transfer.
- **New kernels added** in `rocmhelpers.hip` / `rocmhelpers.h`:
  - `customCudaAddTensorsInplace(float*, const float*, int)` 
  - `customCudaAddTensorsInplace(half*, const half*, int)`
- **Performance optimization**: `accumBuf` is pre-allocated once per `ConvLayer` at construction time (sized for `maxBatchSize`), avoiding per-inference `hipMalloc`/`hipFree` overhead.

### Secondary Fix: Algorithm enumeration buffer overflow
- `miopenConvolutionForwardGetSolutionCount` returns the available count by overwriting the output parameter. The original code used this count to size a fixed stack array `miopenConvSolution_t solutions[2*requestedAlgoCount]` which could overflow. Replaced with `std::vector<miopenConvSolution_t> solutions(availableAlgoCount)` for safe dynamic sizing.

## Key Changes — MIGraphX Backend (New)

Added a complete MIGraphX graph-compiler backend (migraphxbackend.cpp, 1886 lines) as an alternative to the ROCm (MIOpen) backend. MIGraphX compiles the entire neural network into a single fused GPU program, leveraging AMD's graph-level optimizations (operator fusion, memory planning, kernel scheduling).

### Architecture
- **Graph-based inference**: The full model (trunk → policy/value/ownership heads) is constructed as a `migraphx::program` at load time using `MIGraphXGraphBuilder`, compiled once, then cached as `.mxr` files under `~/.katago/migraphxcache/`.
- **Multi-batch compilation**: MIGraphX does not support dynamic batch dimensions. Instead, multiple fixed-batch programs are pre-compiled at sizes `{4, 8, 16, 24, 32, 40, 64}` (capped by `maxBatchSize`). At inference time, `getBestBatchSize()` selects the smallest compiled size ≥ actual batch to minimize GPU waste.
- **Cache system**: Compiled programs are saved/loaded as `.mxr` files with naming format `migraphx_{modelName}_{sha256}_{H}x{W}_batch{N}_fp{0|1}_nhwc{0|1}_{exact|max}.mxr`. First launch compiles all batch sizes (slow); subsequent launches load from cache in seconds.

### Neural Network Components Implemented
| Component | Status |
|-----------|--------|
| Convolution (with padding/dilation/stride) | ✅ |
| BatchNorm (merged scale/bias via unsqueeze+multibroadcast) | ✅ |
| Residual Block | ✅ |
| Global Pooling Residual Block (dual-branch with gpoolToBiasMul) | ✅ |
| Nested Bottleneck Residual Block | ✅ |
| Global Pooling (3 features: mean, mean×scale, max/scale2) | ✅ |
| Policy Head (p1Conv + g1Conv→GPool→bias, p2Conv spatial, pass branch) | ✅ |
| Value Head (v1Conv→GPool→v2Mul→v3Mul) | ✅ |
| Score Value Head (shared v2→sv3Mul) | ✅ |
| Ownership Head (vOwnershipConv→flatten) | ✅ |
| Activations: ReLU, Mish, MishScale8 | ✅ |
| MatMul / FC layers (with optional bias) | ✅ |
| SGF Metadata Encoder | ❌ Disabled |

### FP16 Support
- Enabled by default (when `useFP16Mode` is `Auto` or `True`).
- Input parameters remain `float_type` on host; a `convert` op inside the graph handles float→half on GPU.
- All weights/computation use `half_type`; outputs are cast back to `float` via `static_cast<float>` in the `visit()` lambda.

### Build Integration
- New `USE_BACKEND=MIGRAPHX` option in CMakeLists.txt (~60 lines of build logic).
- Links against `libmigraphx` (and optional `libmigraphx_gpu`) from rocm.
- Registered as `"mgx"` backend prefix in `setup.cpp`, forced NCHW format.
- Backend identification in `main.cpp`: prints `"Using MIGraphX backend"`.

### Known Limitations
- **No dynamic batch**: Fixed batch sizes require pre-compilation; small batches may waste GPU cycles (e.g., actual batch 3 uses compiled batch 4).
- **NCHW only**: NHWC format is silently ignored.
- **SGF Metadata Encoder disabled**: Potential weight shape mismatch, skipped for now.
- **No mask support in global pooling**: Assumes full board at `nnXLen×nnYLen`.

## Change Stats — ROCm
- Commits: `23` (`non-merge: 18`, `merge: 5`) + post-PR bug fixes
- Files touched: `21` + `3` (rocmbackend.cpp, `rocmhelpers.hip`, `rocmhelpers.h`)
- Diffstat: `+9372 / -4009` + `+59 / -28`

## Change Stats — MIGraphX
- Commits: `3` (`non-merge: 3`)
- Files touched: `4` (migraphxbackend.cpp, CMakeLists.txt, setup.cpp, main.cpp)
- Diffstat: `+1977 / -1` (1886 lines new backend + 91 lines build/setup integration)

## Included Commits (Author: Looong01)

### ROCm Backend (`AMD_GPU` branch, 2025-07-28 ~ 2026-03-16)
- `1f2ae46e` 2025-07-28 Add ROCm backend
- `b4555304` 2025-07-28 Fix bugs
- `8b30cb96` 2025-07-31 Update
- `570ced01` 2025-08-01 Fix bugs
- `abb61240` 2025-08-01 Fix bugs
- `bfb292e7` 2025-08-01 All bug fixed
- `4606424f` 2025-08-01 Update
- `1e8ea788` 2025-08-02 test new method
- `c1a09cf3` 2025-08-02 Update
- `0957b88b` 2025-08-02 Test finished
- `c70d841a` 2025-08-02 Update docks
- `1d05ca8d` 2025-08-02 Update gitignore
- `9d4662b7` 2025-08-02 Update new method
- `d40bd509` 2025-08-02 Optimize performance
- `158d24df` 2025-08-13 Update new Convlayer method
- `ec32eb19` 2025-08-13 Merge branch 'master' of https://github.com/Looong01/KataGo-ROCm
- `0bfe0a14` 2025-10-04 Add new compile target
- `f5fbb336` 2025-11-08 Merge branch 'lightvector:master' into master
- `26d8c5bd` 2025-11-08 Add ROCm for Windows support
- `555d2f17` 2025-12-01 Merge branch 'lightvector:master' into master
- `dbc7cfa4` 2026-02-22 Merge branch 'lightvector:master' into master
- `ed396b72` 2026-02-28 Fix bugs
- `ccec62c5` 2026-03-16 Merge branch 'lightvector:master' into master
- `xxxxxxxx` 2026-04-19 Fix critical ConvLayer accumulate bug & algorithm buffer overflow

### MIGraphX Backend (`MIGraphX` branch, 2026-02-27 ~ 2026-04-19)
- `c511c338` 2026-02-27 Add MIGraphX support
- `00cb6881` 2026-04-19 Fix bugs (MIGraphX: 5 structural bugs, GELU→MishScale8, NHWC→NCHW, dimension mismatches)
- `b1da0e06` 2026-04-19 Optimize performance (FP16 default, multi-batch compilation, cache per batch size)